### PR TITLE
docs: Fix errors in the documentation for Request String Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ dataPoint.addEntities({
 })
 
 // second parameter to transform is the initial value
-transform('entry:getNodeOrgInfo', {
+dataPoint.transform('request:getNodeOrgInfo', {
   organization: 'nodejs'
 }).then((acc) => {
   // outputs full result from the remote source
@@ -1223,7 +1223,7 @@ dataPoint.addEntities({
 
 // The third parameter of transform is the options object 
 // where we can pass the `locals` value
-transform('entry:getNodeOrgInfo', null, {
+dataPoint.transform('request:getNodeOrgInfo', {
   locals: {
     organization: 'nodejs'
   }


### PR DESCRIPTION
Fixed all occurances of 'transform('entry:getNodeOrgInfo', {' to
'dataPoint.transform('request:getNodeOrgInfo', {' in the README

Fix request string template example #7