### PR TITLE
Fix custom entity type example

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -2639,7 +2639,6 @@ function resolve(acc:Accumulator, resolveTransform:function):Promise<Accumulator
 const _ = require('lodash')
 
 const DataPoint = require('../')
-const Helpers = DataPoint.helpers
 
 // Entity Class
 function RenderTemplate () {
@@ -2652,7 +2651,7 @@ function RenderTemplate () {
  */
 function create (spec) {
   // create an entity instance
-  const entity = Helpers.createEntity(RenderTemplate, spec)
+  const entity = DataPoint.createEntity(RenderTemplate, spec)
   // set/create template from spec.template value
   entity.template = _.template(_.defaultTo(spec.template, ''))
   return entity
@@ -2676,7 +2675,7 @@ function resolve (accumulator, resolveTransform) {
       const output = spec.template(acc.value)
       // set new accumulator.value
       // this method creates a new acc object
-      return Helpers.set(acc, 'value', output)
+      return DataPoint.set(acc, 'value', output)
     })
 }
 

--- a/packages/data-point/examples/custom-entity-type.js
+++ b/packages/data-point/examples/custom-entity-type.js
@@ -1,7 +1,6 @@
 const _ = require('lodash')
 
 const DataPoint = require('../')
-const Helpers = DataPoint.helpers
 
 // Entity Class
 function RenderTemplate () {}
@@ -13,7 +12,7 @@ function RenderTemplate () {}
  */
 function create (spec) {
   // create an entity instance
-  const entity = Helpers.createEntity(RenderTemplate, spec)
+  const entity = DataPoint.createEntity(RenderTemplate, spec)
   // set/create template from spec.template value
   entity.template = _.template(_.defaultTo(spec.template, ''))
   return entity
@@ -36,7 +35,7 @@ function resolve (accumulator, resolveTransform) {
     const output = spec.template(acc.value)
     // set new accumulator.value
     // this method creates a new acc object
-    return Helpers.set(acc, 'value', output)
+    return DataPoint.set(acc, 'value', output)
   })
 }
 


### PR DESCRIPTION
Closes #11

This is a small change to the custom entity type example and a small change to the `data-point` README to be consistent.

To test the example run `node packages/data-point/examples/custom-entity-type.js` in the terminal.