### PR TITLE
Add accumulator.resolveTransformWith method

### DIFF
--- a/packages/data-point/lib/accumulator/factory.js
+++ b/packages/data-point/lib/accumulator/factory.js
@@ -14,7 +14,7 @@ function Accumulator () {
   this.reducer = undefined
   this.trace = false
   this.context = undefined
-  this.resolveWith = function (value) {
+  this.resolveTransformWith = function (value) {
     if (this.resolvedValue) {
       value = this.resolvedValue
     }

--- a/packages/data-point/lib/accumulator/factory.js
+++ b/packages/data-point/lib/accumulator/factory.js
@@ -8,7 +8,7 @@ const LocalsFactory = require('../locals/factory')
  */
 function Accumulator () {
   this.value = undefined
-  this.resolvedValue = null
+  this.isResolved = false
   this.locals = undefined
   this.values = undefined
   this.reducer = undefined
@@ -16,7 +16,7 @@ function Accumulator () {
   this.context = undefined
   this.resolveTransformWith = function (value) {
     return {
-      value: this.resolvedValue || value,
+      value: this.isResolved ? this.value : value,
       isResolved: true
     }
   }

--- a/packages/data-point/lib/accumulator/factory.js
+++ b/packages/data-point/lib/accumulator/factory.js
@@ -15,11 +15,7 @@ function Accumulator () {
   this.trace = false
   this.context = undefined
   this.resolveTransformWith = function (value) {
-    if (this.resolvedValue) {
-      value = this.resolvedValue
-    }
-
-    return { value, isResolved: true }
+    return { value: this.resolvedValue || value, isResolved: true }
   }
 }
 

--- a/packages/data-point/lib/accumulator/factory.js
+++ b/packages/data-point/lib/accumulator/factory.js
@@ -15,7 +15,10 @@ function Accumulator () {
   this.trace = false
   this.context = undefined
   this.resolveTransformWith = function (value) {
-    return { value: this.resolvedValue || value, isResolved: true }
+    return {
+      value: this.resolvedValue || value,
+      isResolved: true
+    }
   }
 }
 

--- a/packages/data-point/lib/accumulator/factory.js
+++ b/packages/data-point/lib/accumulator/factory.js
@@ -8,11 +8,19 @@ const LocalsFactory = require('../locals/factory')
  */
 function Accumulator () {
   this.value = undefined
+  this.resolvedValue = null
   this.locals = undefined
   this.values = undefined
   this.reducer = undefined
   this.trace = false
   this.context = undefined
+  this.resolveWith = function (value) {
+    if (this.resolvedValue) {
+      value = this.resolvedValue
+    }
+
+    return { value, isResolved: true }
+  }
 }
 
 module.exports.Accumulator = Accumulator

--- a/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
+++ b/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
@@ -42,8 +42,8 @@ describe('entity.transform.value', () => {
     return transform('transform:a1', {
       message: 'hello world'
     }).then(acc => {
-      expect(acc.value).toEqual('HELLO WORLD')
       expect(acc.resolvedValue).toBe(null)
+      expect(acc.value).toEqual('HELLO WORLD')
     })
   })
 

--- a/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
+++ b/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
@@ -43,6 +43,7 @@ describe('entity.transform.value', () => {
       message: 'hello world'
     }).then(acc => {
       expect(acc.value).toEqual('HELLO WORLD')
+      expect(acc.resolvedValue).toBe(null)
     })
   })
 
@@ -50,6 +51,7 @@ describe('entity.transform.value', () => {
     return transform('transform:a2', {
       message: 'hello world'
     }).then(acc => {
+      expect(acc.resolvedValue).toBe('resolved value')
       expect(acc.value).toBe('resolved value')
     })
   })
@@ -58,6 +60,7 @@ describe('entity.transform.value', () => {
     return transform('transform:a3', {
       message: 'hello world'
     }).then(acc => {
+      expect(acc.resolvedValue).toBe('resolved value')
       expect(acc.value).toBe('resolved value')
     })
   })

--- a/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
+++ b/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
@@ -45,4 +45,20 @@ describe('entity.transform.value', () => {
       expect(acc.value).toEqual('HELLO WORLD')
     })
   })
+
+  test('should resolve early if it encounters accumulator.resolve', () => {
+    return transform('transform:a2', {
+      message: 'hello world'
+    }).then(acc => {
+      expect(acc.value).toBe('resolved value')
+    })
+  })
+
+  test('should not change the resolved value if it reaches another accumulator.resolve', () => {
+    return transform('transform:a3', {
+      message: 'hello world'
+    }).then(acc => {
+      expect(acc.value).toBe('resolved value')
+    })
+  })
 })

--- a/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
+++ b/packages/data-point/lib/entity-types/entity-transform/reducer.test.js
@@ -42,7 +42,7 @@ describe('entity.transform.value', () => {
     return transform('transform:a1', {
       message: 'hello world'
     }).then(acc => {
-      expect(acc.resolvedValue).toBe(null)
+      expect(acc.isResolved).toBe(false)
       expect(acc.value).toEqual('HELLO WORLD')
     })
   })
@@ -51,7 +51,7 @@ describe('entity.transform.value', () => {
     return transform('transform:a2', {
       message: 'hello world'
     }).then(acc => {
-      expect(acc.resolvedValue).toBe('resolved value')
+      expect(acc.isResolved).toBe(true)
       expect(acc.value).toBe('resolved value')
     })
   })
@@ -60,8 +60,32 @@ describe('entity.transform.value', () => {
     return transform('transform:a3', {
       message: 'hello world'
     }).then(acc => {
-      expect(acc.resolvedValue).toBe('resolved value')
+      expect(acc.isResolved).toBe(true)
       expect(acc.value).toBe('resolved value')
+    })
+  })
+  test('should resolve with false', () => {
+    return transform('transform:a4', {
+      message: 'hello world'
+    }).then(acc => {
+      expect(acc.isResolved).toBe(true)
+      expect(acc.value).toBe(false)
+    })
+  })
+  test('should resolve with undefined', () => {
+    return transform('transform:a5', {
+      message: 'hello world'
+    }).then(acc => {
+      expect(acc.isResolved).toBe(true)
+      expect(acc.value).toBe(undefined)
+    })
+  })
+  test('should resolve with null', () => {
+    return transform('transform:a6', {
+      message: 'hello world'
+    }).then(acc => {
+      expect(acc.isResolved).toBe(true)
+      expect(acc.value).toBe(null)
     })
   })
 })

--- a/packages/data-point/lib/resolve/reducer-function.js
+++ b/packages/data-point/lib/resolve/reducer-function.js
@@ -46,7 +46,7 @@ module.exports.getCallbackFunction = getCallbackFunction
  */
 function resolve (filterStore, accumulator, reducerFunction) {
   // if the accumulator already as a resolvedValue, return the accumulator without updating
-  if (accumulator.resolvedValue) {
+  if (accumulator.isResolved) {
     return accumulator
   }
 
@@ -89,10 +89,7 @@ function resolve (filterStore, accumulator, reducerFunction) {
 
         // if the result is a resolved value then return the accumulator with that value and a resolvedValue
         if (value.isResolved) {
-          return utils.assign(currentAccumulator, {
-            value: value.value,
-            resolvedValue: value.value
-          })
+          return utils.assign(currentAccumulator, value)
         }
 
         resolve(utils.set(currentAccumulator, 'value', value))
@@ -106,10 +103,7 @@ function resolve (filterStore, accumulator, reducerFunction) {
     .then(result => {
       // if the result is a resolved value then return the accumulator with that value and a resolvedValue
       if (result.isResolved) {
-        return utils.assign(currentAccumulator, {
-          value: result.value,
-          resolvedValue: result.value
-        })
+        return utils.assign(currentAccumulator, result)
       }
 
       return utils.set(currentAccumulator, 'value', result)

--- a/packages/data-point/lib/resolve/reducer-function.js
+++ b/packages/data-point/lib/resolve/reducer-function.js
@@ -89,7 +89,7 @@ function resolve (filterStore, accumulator, reducerFunction) {
 
         // if the result is a resolved value then return the accumulator with that value and a resolvedValue
         if (value.isResolved) {
-          return utils.assign(currentAccumulator, value)
+          resolve(utils.assign(currentAccumulator, value))
         }
 
         resolve(utils.set(currentAccumulator, 'value', value))

--- a/packages/data-point/lib/resolve/reducer-function.js
+++ b/packages/data-point/lib/resolve/reducer-function.js
@@ -45,6 +45,11 @@ module.exports.getCallbackFunction = getCallbackFunction
  * @returns {Promise<Accumulator>}
  */
 function resolve (filterStore, accumulator, reducerFunction) {
+  // if the accumulator already as a resolvedValue, return the accumulator without updating
+  if (accumulator.resolvedValue) {
+    return accumulator
+  }
+
   const callbackFunction = reducerFunction.isFunction
     ? reducerFunction.body
     : getCallbackFunction(filterStore, reducerFunction)
@@ -81,6 +86,15 @@ function resolve (filterStore, accumulator, reducerFunction) {
         if (err) {
           return reject(err)
         }
+
+        // if the result is a resolved value then return the accumulator with that value and a resolvedValue
+        if (value.isResolved) {
+          return utils.assign(currentAccumulator, {
+            value: value.value,
+            resolvedValue: value.value
+          })
+        }
+
         resolve(utils.set(currentAccumulator, 'value', value))
       })
     })
@@ -88,9 +102,21 @@ function resolve (filterStore, accumulator, reducerFunction) {
 
   // callbackFunction is assumed to be either sync
   // or Promise returned value
-  return Promise.try(callbackFunction.bind(null, accumulator)).then(result => {
-    return utils.set(currentAccumulator, 'value', result)
-  })
+  return Promise.try(callbackFunction.bind(null, accumulator))
+    .then(result => {
+      // if the result is a resolved value then return the accumulator with that value and a resolvedValue
+      if (result.isResolved) {
+        return utils.assign(currentAccumulator, {
+          value: result.value,
+          resolvedValue: result.value
+        })
+      }
+
+      return utils.set(currentAccumulator, 'value', result)
+    })
+    .catch(err => {
+      console.log(err)
+    })
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/resolve/reducer-function.test.js
+++ b/packages/data-point/lib/resolve/reducer-function.test.js
@@ -139,7 +139,7 @@ describe('resolve#filter.resolve', () => {
     return resolveFunction
       .resolve(store.filters, accumulator, reducer)
       .then(result => {
-        expect(result.resolvedValue).toBe('resolved value')
+        expect(result.isResolved).toBe(true)
         expect(result.value).toBe('resolved value')
       })
   })

--- a/packages/data-point/lib/resolve/reducer-function.test.js
+++ b/packages/data-point/lib/resolve/reducer-function.test.js
@@ -133,14 +133,14 @@ describe('resolve#filter.resolve', () => {
     })
 
     const reducer = reducerFactory.create(acc => {
-      return acc.resolveTransformWith('test')
+      return acc.resolveTransformWith('resolved value')
     })
 
     return resolveFunction
       .resolve(store.filters, accumulator, reducer)
       .then(result => {
-        expect(result.resolvedValue).toBe('test')
-        expect(result.value).toBe('test')
+        expect(result.resolvedValue).toBe('resolved value')
+        expect(result.value).toBe('resolved value')
       })
   })
 })

--- a/packages/data-point/lib/resolve/reducer-function.test.js
+++ b/packages/data-point/lib/resolve/reducer-function.test.js
@@ -127,18 +127,19 @@ describe('resolve#filter.resolve', () => {
       })
   })
 
-  test('resolves early if encountering resolveWith', () => {
+  test('resolves early if encountering resolveTransformWith', () => {
     const accumulator = AccumulatorFactory.create({
       value: 'test'
     })
 
     const reducer = reducerFactory.create(acc => {
-      return acc.resolveWith('test')
+      return acc.resolveTransformWith('test')
     })
 
     return resolveFunction
       .resolve(store.filters, accumulator, reducer)
       .then(result => {
+        expect(result.resolvedValue).toBe('test')
         expect(result.value).toBe('test')
       })
   })

--- a/packages/data-point/lib/resolve/reducer-function.test.js
+++ b/packages/data-point/lib/resolve/reducer-function.test.js
@@ -126,4 +126,20 @@ describe('resolve#filter.resolve', () => {
         expect(err).toHaveProperty('message', 'Test')
       })
   })
+
+  test('resolves early if encountering resolveWith', () => {
+    const accumulator = AccumulatorFactory.create({
+      value: 'test'
+    })
+
+    const reducer = reducerFactory.create(acc => {
+      return acc.resolveWith('test')
+    })
+
+    return resolveFunction
+      .resolve(store.filters, accumulator, reducer)
+      .then(result => {
+        expect(result.value).toBe('test')
+      })
+  })
 })

--- a/packages/data-point/test/definitions/transform.js
+++ b/packages/data-point/test/definitions/transform.js
@@ -6,14 +6,14 @@ module.exports = {
   ],
   'transform:a2': [
     'transform:a0',
-    acc => acc.resolveWith('resolved value'),
+    acc => acc.resolveTransformWith('resolved value'),
     (acc, next) => next(null, 'never returned value')
   ],
   'transform:a3': [
     'transform:a0',
-    acc => acc.resolveWith('resolved value'),
+    acc => acc.resolveTransformWith('resolved value'),
     acc => 'some other value',
-    acc => acc.resolveWith('never resolved value'),
+    acc => acc.resolveTransformWith('never resolved value'),
     (acc, next) => next(null, 'never returned value')
   ]
 }

--- a/packages/data-point/test/definitions/transform.js
+++ b/packages/data-point/test/definitions/transform.js
@@ -3,5 +3,17 @@ module.exports = {
   'transform:a1': [
     'transform:a0',
     (acc, next) => next(null, acc.value.toUpperCase())
+  ],
+  'transform:a2': [
+    'transform:a0',
+    acc => acc.resolveWith('resolved value'),
+    (acc, next) => next(null, 'never returned value')
+  ],
+  'transform:a3': [
+    'transform:a0',
+    acc => acc.resolveWith('resolved value'),
+    acc => 'some other value',
+    acc => acc.resolveWith('never resolved value'),
+    (acc, next) => next(null, 'never returned value')
   ]
 }

--- a/packages/data-point/test/definitions/transform.js
+++ b/packages/data-point/test/definitions/transform.js
@@ -15,5 +15,25 @@ module.exports = {
     acc => 'some other value',
     acc => acc.resolveTransformWith('never resolved value'),
     (acc, next) => next(null, 'never returned value')
+  ],
+  'transform:a4': [
+    'transform:a0',
+    acc => acc.resolveTransformWith(false),
+    acc => acc.resolveTransformWith('never resolved value'),
+    (acc, next) => next(null, 'never returned value')
+  ],
+  'transform:a5': [
+    'transform:a0',
+    acc => acc.resolveTransformWith(undefined),
+    acc => 'some other value',
+    acc => acc.resolveTransformWith('never resolved value'),
+    (acc, next) => next(null, 'never returned value')
+  ],
+  'transform:a6': [
+    'transform:a0',
+    acc => acc.resolveTransformWith(null),
+    acc => 'some other value',
+    acc => acc.resolveTransformWith('never resolved value'),
+    (acc, next) => next(null, 'never returned value')
   ]
 }


### PR DESCRIPTION
This is a PR trying to solve the `resolveTransformWith` feature suggestion in #15. The issue says the spec is a WIP, so if this PR needs extra work or just gets rejected I understand! 😄 

This implements the `resolveTransformWith` method by adding the method in the accumulator factory and then checking for a "resolved value" within `FunctionReducer#resolve` to shortcut any callback that follows the `resolveTransformWith` call to ensure that the `acc.resolvedValue` is not overwritten.

The reason this pattern is used is because `FunctionReducer#resolve` (essentially) promisifies and chains the callbacks, and escaping that chain requires a `throw`.

I've written tests to cover the new code, but noticed there are no tests for accumulator/factory, and didn't introduce any (that code is sorta covered through other tests anyway).

Any comments or feedback is welcome! If this solution is not acceptable for inclusion, please let me know where it went wrong. Thanks! 🙌 🙌 🙌