### PR TITLE
Add default options.entityTypes object

### DIFF
--- a/packages/data-point/lib/core/factory.js
+++ b/packages/data-point/lib/core/factory.js
@@ -43,7 +43,7 @@ function create (spec) {
     values: {},
     reducers: {},
     entities: {},
-    entryPoints: {}
+    entityTypes: {}
   })
 
   const entityTypes = storeEntityTypes.create()


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Replace "entryPoints" property with "entityTypes" when adding default options.

<!-- Why are these changes necessary? -->
**Why**: entryPoints is never used.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
