### PR TITLE
Add shorthand for object reducer pass through values

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -571,7 +571,12 @@ ObjectReducers are plain objects where the values are TransformExpressions. They
 **Transforming an object:**
 
 ```js
-const inputData = {
+const objectReducer = {
+  y: '$x.y',
+  zPlusOne: ['$x.y.z', (acc) => acc.value + 1]
+}
+
+const input = {
   x: {
     y: {
       z: 2
@@ -579,12 +584,7 @@ const inputData = {
   }
 }
 
-const objectReducer = {
-  y: '$x.y',
-  zPlusOne: ['$x.y.z', (acc) => acc.value + 1]
-}
-
-// output from dataPoint.transform(objectReducer, inputData):
+// output from dataPoint.transform(objectReducer, input):
 
 {
   y: {
@@ -625,15 +625,6 @@ dataPoint.transform(objectReducer, planetIds)
 Each of the TransformExpressions, including the nested ones, are resolved against the same accumulator value. This means that input objects can be rearranged at any level:
 
 ```js
-const inputData = {
-  a: 'A',
-  b: 'B',
-  c: {
-    x: 'X',
-    y: 'Y'
-  }
-})
-
 // some data will move to a higher level of nesting,
 // but other data will move deeper into the object
 const objectReducer = {
@@ -645,7 +636,16 @@ const objectReducer = {
   }
 }
 
-// output from dataPoint.transform(objectReducer, inputData):
+const input = {
+  a: 'A',
+  b: 'B',
+  c: {
+    x: 'X',
+    y: 'Y'
+  }
+})
+
+// output from dataPoint.transform(objectReducer, input):
 
 {
   x: 'X',
@@ -660,13 +660,6 @@ const objectReducer = {
 Each of the TransformExpressions might also contain more ObjectReducers (which might contain TransformExpressions, and so on). Notice how the output changes based on the position of the ObjectReducers in the two expressions:
 
 ```js
-const inputData = {
-  a: {
-    a: 1,
-    b: 2
-  }
-}
-
 const objectReducer = {
   x: [
     '$a',
@@ -686,7 +679,14 @@ const objectReducer = {
   ]
 }
 
-// output from dataPoint.transform(objectReducer, inputData):
+const input = {
+  a: {
+    a: 1,
+    b: 2
+  }
+}
+
+// output from dataPoint.transform(objectReducer, input):
 
 {
   x: {
@@ -695,6 +695,35 @@ const objectReducer = {
   y: {
     a: 1,
     b: 2
+  }
+}
+```
+
+**TransformExpression shorthand:**
+
+If a property's value is `true`, the value for that key is passed directly from the input to the output:
+
+```js
+const objectReducer = {
+  a: {
+    b: true, // in this case, true is shorthand for '$a.b'
+    c: '$a.b'
+  }
+}
+
+const input = {
+  a: {
+    b: 'B',
+    c: 'C'
+  }
+}
+
+// output from dataPoint.transform(objectReducer, input):
+
+{
+  a: {
+    b: 'B',
+    c: 'B'
   }
 }
 ```

--- a/packages/data-point/lib/reducer-object/__snapshots__/factory.test.js.snap
+++ b/packages/data-point/lib/reducer-object/__snapshots__/factory.test.js.snap
@@ -46,6 +46,23 @@ Array [
     ],
     "transform": TransformExpression {
       "reducers": Array [
+        ReducerPath {
+          "asCollection": false,
+          "body": [Function],
+          "name": "b1.b2",
+          "type": "ReducerPath",
+        },
+      ],
+      "typeOf": "TransformExpression",
+    },
+  },
+  Object {
+    "path": Array [
+      "b1",
+      "c2",
+    ],
+    "transform": TransformExpression {
+      "reducers": Array [
         ReducerObject {
           "props": Array [
             Object {
@@ -74,6 +91,22 @@ Array [
                     "asCollection": false,
                     "body": [Function],
                     "name": "b1.b2.b3",
+                    "type": "ReducerPath",
+                  },
+                ],
+                "typeOf": "TransformExpression",
+              },
+            },
+            Object {
+              "path": Array [
+                "c4",
+              ],
+              "transform": TransformExpression {
+                "reducers": Array [
+                  ReducerPath {
+                    "asCollection": false,
+                    "body": [Function],
+                    "name": "c4",
                     "type": "ReducerPath",
                   },
                 ],

--- a/packages/data-point/lib/reducer-object/factory.js
+++ b/packages/data-point/lib/reducer-object/factory.js
@@ -4,6 +4,10 @@ const REDUCER_OBJECT = 'ReducerObject'
 
 module.exports.type = REDUCER_OBJECT
 
+const IDENTITY_PLACEHOLDER = true
+
+module.exports.IDENTITY_PLACEHOLDER = IDENTITY_PLACEHOLDER
+
 /**
  * @class
  * @property {string} type - @see reducerType
@@ -40,12 +44,16 @@ function getReducerProps (
   reducerProps = []
 ) {
   for (let key of Object.keys(source)) {
-    const value = source[key]
+    let value = source[key]
     const fullPath = path.concat(key)
     if (isPlainObject(value)) {
       // NOTE: recursive call
       getReducerProps(createTransform, value, fullPath, reducerProps)
       continue
+    }
+
+    if (value === IDENTITY_PLACEHOLDER) {
+      value = `$${fullPath.join('.')}`
     }
 
     reducerProps.push({

--- a/packages/data-point/lib/reducer-object/factory.test.js
+++ b/packages/data-point/lib/reducer-object/factory.test.js
@@ -21,10 +21,12 @@ describe('reducer/reducer-function#getReducerProps', () => {
       a1: '$a[]',
       b1: {
         a2: ['$a2', () => false],
-        b2: [
+        b2: true,
+        c2: [
           {
             a3: 'transform:entity-name',
-            b3: '$b1.b2.b3'
+            b3: '$b1.b2.b3',
+            c4: true
           }
         ]
       }

--- a/packages/data-point/lib/reducer-object/resolve.test.js
+++ b/packages/data-point/lib/reducer-object/resolve.test.js
@@ -149,4 +149,52 @@ describe('resolve#reducerObject.resolve', () => {
       })
     })
   })
+
+  it('should resolve a reducer object with placeholders', () => {
+    const reducer = reducerFactory.create(createTransform, {
+      a: {
+        x: true,
+        y: '$a.x',
+        z1: {
+          z2: {
+            z3: true
+          }
+        }
+      }
+    })
+
+    const accumulator = AccumulatorFactory.create({
+      value: {
+        a: {
+          x: 'X',
+          y: 'Y',
+          z1: {
+            z2: {
+              z3: 'Z'
+            }
+          }
+        },
+        b: 'B'
+      }
+    })
+
+    return resolveObject(
+      dataPoint,
+      resolveTransform,
+      accumulator,
+      reducer
+    ).then(result => {
+      expect(result.value).toEqual({
+        a: {
+          x: 'X',
+          y: 'X',
+          z1: {
+            z2: {
+              z3: 'Z'
+            }
+          }
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Makes it easier to use object reducers in place of _.pick

<!-- Why are these changes necessary? -->
**Why**: #86 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->