### PR TITLE
Remove empty lifecycle transforms

### DIFF
--- a/packages/data-point/lib/entity-types/base-entity/factory.js
+++ b/packages/data-point/lib/entity-types/base-entity/factory.js
@@ -17,7 +17,9 @@ function create (Factory, spec, id) {
     entity.before = createTransform(spec.before)
   }
 
-  entity.value = createTransform(spec.value)
+  if (spec.value) {
+    entity.value = createTransform(spec.value)
+  }
 
   if (spec.after) {
     entity.after = createTransform(spec.after)

--- a/packages/data-point/lib/entity-types/base-entity/factory.js
+++ b/packages/data-point/lib/entity-types/base-entity/factory.js
@@ -13,9 +13,16 @@ function create (Factory, spec, id) {
 
   entity.id = id
   entity.value = createTransform(spec.value)
-  entity.before = createTransform(spec.before)
+
+  if (spec.before) {
+    entity.before = createTransform(spec.before)
+  }
+
   entity.error = createTransform(spec.error)
-  entity.after = createTransform(spec.after)
+  if (spec.after) {
+    entity.after = createTransform(spec.after)
+  }
+
   entity.params = deepFreeze(defaultTo(spec.params, {}))
 
   return entity

--- a/packages/data-point/lib/entity-types/base-entity/factory.js
+++ b/packages/data-point/lib/entity-types/base-entity/factory.js
@@ -12,15 +12,19 @@ function create (Factory, spec, id) {
   const entity = new Factory(spec)
 
   entity.id = id
-  entity.value = createTransform(spec.value)
 
   if (spec.before) {
     entity.before = createTransform(spec.before)
   }
 
-  entity.error = createTransform(spec.error)
+  entity.value = createTransform(spec.value)
+
   if (spec.after) {
     entity.after = createTransform(spec.after)
+  }
+
+  if (spec.error) {
+    entity.error = createTransform(spec.error)
   }
 
   entity.params = deepFreeze(defaultTo(spec.params, {}))

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -10,7 +10,7 @@ const utils = require('../../utils')
 function resolveErrorReducers (error, accumulator, resolveReducer) {
   const errorTransform = accumulator.reducer.spec.error
 
-  if (errorTransform.reducers.length === 0) {
+  if (!errorTransform || errorTransform.reducers.length === 0) {
     return Promise.reject(error)
   }
 
@@ -111,19 +111,9 @@ function resolveEntity (
     .then(acc =>
       resolveMiddleware(manager, `${reducer.entityType}:before`, acc)
     )
-    .then(
-      acc =>
-        _.get(acc, 'reducer.spec.before')
-          ? resolveTransform(acc, acc.reducer.spec.before)
-          : acc
-    )
+    .then(acc => resolveTransform(acc, acc.reducer.spec.before))
     .then(acc => mainResolver(acc, resolveTransform))
-    .then(
-      acc =>
-        _.get(acc, 'reducer.spec.after')
-          ? resolveTransform(acc, acc.reducer.spec.after)
-          : acc
-    )
+    .then(acc => resolveTransform(acc, acc.reducer.spec.after))
     .then(acc =>
       middleware.resolve(manager, `${reducer.entityType}:after`, acc)
     )

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -111,9 +111,19 @@ function resolveEntity (
     .then(acc =>
       resolveMiddleware(manager, `${reducer.entityType}:before`, acc)
     )
-    .then(acc => resolveTransform(acc, acc.reducer.spec.before))
+    .then(
+      acc =>
+        _.get(acc, 'reducer.spec.before')
+          ? resolveTransform(acc, acc.reducer.spec.before)
+          : acc
+    )
     .then(acc => mainResolver(acc, resolveTransform))
-    .then(acc => resolveTransform(acc, acc.reducer.spec.after))
+    .then(
+      acc =>
+        _.get(acc, 'reducer.spec.after')
+          ? resolveTransform(acc, acc.reducer.spec.after)
+          : acc
+    )
     .then(acc =>
       middleware.resolve(manager, `${reducer.entityType}:after`, acc)
     )

--- a/packages/data-point/lib/entity-types/entity-collection/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.test.js
@@ -6,7 +6,7 @@ const modelFactory = require('./factory')
 test('modelFactory#create default', () => {
   const result = modelFactory.create({})
 
-  expect(result.error).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('error')
   expect(result).not.toHaveProperty('before')
   expect(result).not.toHaveProperty('after')
   expect(result.params).toEqual({})

--- a/packages/data-point/lib/entity-types/entity-collection/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.test.js
@@ -11,7 +11,7 @@ test('modelFactory#create default', () => {
   expect(result).not.toHaveProperty('after')
   expect(result.params).toEqual({})
 
-  expect(result.value).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('value')
   expect(result.compose).toBeInstanceOf(Array)
 })
 

--- a/packages/data-point/lib/entity-types/entity-collection/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.test.js
@@ -7,8 +7,8 @@ test('modelFactory#create default', () => {
   const result = modelFactory.create({})
 
   expect(result.error).toHaveProperty('typeOf', 'TransformExpression')
-  expect(result.before).toHaveProperty('typeOf', 'TransformExpression')
-  expect(result.after).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('before')
+  expect(result).not.toHaveProperty('after')
   expect(result.params).toEqual({})
 
   expect(result.value).toHaveProperty('typeOf', 'TransformExpression')

--- a/packages/data-point/lib/entity-types/entity-control/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-control/factory.test.js
@@ -14,7 +14,7 @@ test('Factory#create', () => {
 
   expect(control).not.toHaveProperty('before')
   expect(control).not.toHaveProperty('after')
-  expect(control).toHaveProperty('error')
+  expect(control).not.toHaveProperty('error')
   expect(control).toHaveProperty('params')
   expect(control).toHaveProperty('select')
 })

--- a/packages/data-point/lib/entity-types/entity-control/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-control/factory.test.js
@@ -12,8 +12,8 @@ test('Factory#create', () => {
     ]
   })
 
-  expect(control).toHaveProperty('before')
-  expect(control).toHaveProperty('after')
+  expect(control).not.toHaveProperty('before')
+  expect(control).not.toHaveProperty('after')
   expect(control).toHaveProperty('error')
   expect(control).toHaveProperty('params')
   expect(control).toHaveProperty('select')

--- a/packages/data-point/lib/entity-types/entity-entry/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-entry/factory.test.js
@@ -8,8 +8,8 @@ test('Factory#create', () => {
     value: ['$foo', (acc, done) => {}]
   })
 
-  expect(obj).toHaveProperty('before')
-  expect(obj).toHaveProperty('after')
+  expect(obj).not.toHaveProperty('before')
+  expect(obj).not.toHaveProperty('after')
   expect(obj).toHaveProperty('error')
   expect(obj).toHaveProperty('params')
   expect(obj).toHaveProperty('value')

--- a/packages/data-point/lib/entity-types/entity-entry/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-entry/factory.test.js
@@ -10,7 +10,7 @@ test('Factory#create', () => {
 
   expect(obj).not.toHaveProperty('before')
   expect(obj).not.toHaveProperty('after')
-  expect(obj).toHaveProperty('error')
+  expect(obj).not.toHaveProperty('error')
   expect(obj).toHaveProperty('params')
   expect(obj).toHaveProperty('value')
 })

--- a/packages/data-point/lib/entity-types/entity-hash/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.test.js
@@ -7,8 +7,8 @@ test('factory#create default', () => {
   const result = factory.create({})
 
   expect(result.error).toHaveProperty('typeOf', 'TransformExpression')
-  expect(result.before).toHaveProperty('typeOf', 'TransformExpression')
-  expect(result.after).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('before')
+  expect(result).not.toHaveProperty('after')
   expect(result.value).toHaveProperty('typeOf', 'TransformExpression')
   expect(result.params).toEqual({})
 

--- a/packages/data-point/lib/entity-types/entity-hash/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.test.js
@@ -9,7 +9,7 @@ test('factory#create default', () => {
   expect(result).not.toHaveProperty('error')
   expect(result).not.toHaveProperty('before')
   expect(result).not.toHaveProperty('after')
-  expect(result.value).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('value')
   expect(result.params).toEqual({})
 
   expect(result.compose).toBeInstanceOf(Array)

--- a/packages/data-point/lib/entity-types/entity-hash/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.test.js
@@ -6,7 +6,7 @@ const factory = require('./factory')
 test('factory#create default', () => {
   const result = factory.create({})
 
-  expect(result.error).toHaveProperty('typeOf', 'TransformExpression')
+  expect(result).not.toHaveProperty('error')
   expect(result).not.toHaveProperty('before')
   expect(result).not.toHaveProperty('after')
   expect(result.value).toHaveProperty('typeOf', 'TransformExpression')

--- a/packages/data-point/lib/entity-types/entity-request/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/factory.test.js
@@ -16,7 +16,7 @@ describe('create', () => {
     expect(request).toHaveProperty('id')
     expect(request).not.toHaveProperty('before')
     expect(request).not.toHaveProperty('after')
-    expect(request).toHaveProperty('error')
+    expect(request).not.toHaveProperty('error')
     expect(request).toHaveProperty('params')
   })
   test('It should have url', () => {

--- a/packages/data-point/lib/entity-types/entity-request/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/factory.test.js
@@ -14,8 +14,8 @@ describe('create', () => {
   })
   test('It should have defaults', () => {
     expect(request).toHaveProperty('id')
-    expect(request).toHaveProperty('before')
-    expect(request).toHaveProperty('after')
+    expect(request).not.toHaveProperty('before')
+    expect(request).not.toHaveProperty('after')
     expect(request).toHaveProperty('error')
     expect(request).toHaveProperty('params')
   })

--- a/packages/data-point/lib/entity-types/entity-schema/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-schema/factory.test.js
@@ -20,6 +20,6 @@ test('Factory#create', () => {
   expect(obj).toHaveProperty('options')
   expect(obj).not.toHaveProperty('before')
   expect(obj).not.toHaveProperty('after')
-  expect(obj).toHaveProperty('error')
+  expect(obj).not.toHaveProperty('error')
   expect(obj).toHaveProperty('params')
 })

--- a/packages/data-point/lib/entity-types/entity-schema/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-schema/factory.test.js
@@ -18,8 +18,8 @@ test('Factory#create', () => {
 
   expect(obj).toHaveProperty('schema')
   expect(obj).toHaveProperty('options')
-  expect(obj).toHaveProperty('before')
-  expect(obj).toHaveProperty('after')
+  expect(obj).not.toHaveProperty('before')
+  expect(obj).not.toHaveProperty('after')
   expect(obj).toHaveProperty('error')
   expect(obj).toHaveProperty('params')
 })

--- a/packages/data-point/lib/transform-expression/resolve.js
+++ b/packages/data-point/lib/transform-expression/resolve.js
@@ -13,7 +13,7 @@ const resolveReducer = require('../reducer').resolve
  * @returns {Promise<Accumulator>}
  */
 function resolve (manager, accumulator, transform) {
-  if (transform.reducers.length === 0) {
+  if (!transform || transform.reducers.length === 0) {
     return Promise.resolve(accumulator)
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This will introduce a change that omits the lifecycle reducers from entities if they're not defined in the spec during their creation.

<!-- Why are these changes necessary? -->
**Why**: This reduces the noise when debugging entities by removing unused keys. It could also improve the memory use by reducing the size of the objects being created.

<!-- How were these changes implemented? -->
**How**: Modifications to the `base-entity/factory#create` that checks for the existence of the `spec.before`/`spec.after`/`spec.error`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [N/A] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [N/A] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
