### PR TITLE
feat(data-point/entities,reducers): normalize asCollection behaviour

### DIFF
--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -143,10 +143,8 @@ module.exports.resolveEntity = resolveEntity
 
 function resolve (manager, resolveReducer, accumulator, reducer, mainResolver) {
   const resolveTransform = _.partial(resolveReducer, manager)
-  const shouldMapCollection =
-    reducer.asCollection && accumulator.value instanceof Array
 
-  if (!shouldMapCollection) {
+  if (!reducer.asCollection) {
     return resolveEntity(
       manager,
       resolveTransform,
@@ -154,6 +152,10 @@ function resolve (manager, resolveReducer, accumulator, reducer, mainResolver) {
       reducer,
       mainResolver
     )
+  }
+
+  if (!Array.isArray(accumulator.value)) {
+    return Promise.resolve(utils.set(accumulator, 'value', undefined))
   }
 
   return Promise.map(accumulator.value, itemValue => {

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -232,4 +232,13 @@ describe('ResolveEntity.resolve', () => {
       expect(acc).toHaveProperty('value', ['bar'])
     })
   })
+
+  test('It should return undefined if accumulator is not Array', () => {
+    const resolver = (acc, resolveTransform) => {
+      return Promise.resolve(acc)
+    }
+    return resolve(resolver)('hash:asIs[]', {}).then(acc => {
+      expect(acc.value).toBeUndefined()
+    })
+  })
 })

--- a/packages/data-point/lib/reducer-path/factory.js
+++ b/packages/data-point/lib/reducer-path/factory.js
@@ -73,7 +73,7 @@ function mapFromAccumulatorValue (jsonPath, acc) {
     return _.map(acc.value, jsonPath)
   }
 
-  return null
+  return undefined
 }
 
 module.exports.mapFromAccumulatorValue = mapFromAccumulatorValue

--- a/packages/data-point/lib/reducer-path/factory.test.js
+++ b/packages/data-point/lib/reducer-path/factory.test.js
@@ -46,7 +46,7 @@ describe('ReducerPath getters', () => {
   })
 
   it('reducer/reducer-path#mapFromAccumulatorValue', () => {
-    expect(factory.mapFromAccumulatorValue('a', { value: {} })).toBeNull()
+    expect(factory.mapFromAccumulatorValue('a', { value: {} })).toBeUndefined()
     expect(factory.mapFromAccumulatorValue('a', acc)).toEqual([2, 4])
   })
 })
@@ -205,6 +205,6 @@ describe('ReducerPath#body', () => {
       }
     }
     const result = factory.create('$a.b.c[]').body(acc)
-    expect(result).toBe(null)
+    expect(result).toBe(undefined)
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: mapping an entity against a non `Array` will now return `undefined` (before it
would resolve as a single item), mapping with a reducer-path used to return `null`, it will now
return `undefined` if the value is not an `Array`.

closes #60

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: normalize asCollection behavior 

<!-- Why are these changes necessary? -->
**Why**: to expect same behavior when mapping against a non array value

<!-- How were these changes implemented? -->
**How**:  changing base-entity.resolve and pat-reducer.factory

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [N/A] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [N/A] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
