### PR TITLE
Remove unused helper functions

### DIFF
--- a/packages/data-point/lib/helpers/helpers.js
+++ b/packages/data-point/lib/helpers/helpers.js
@@ -1,42 +1,8 @@
 'use strict'
 
 const _ = require('lodash')
-const Promise = require('bluebird')
 const resolveTransform = require('../transform-expression').resolve
 const AccumulatorFactory = require('../accumulator/factory')
-
-function reducify (method) {
-  return function () {
-    const partialArguments = Array.prototype.slice.call(arguments)
-    return function (acc, done) {
-      const methodArguments = [acc.value].concat(partialArguments)
-      const result = method.apply(null, methodArguments)
-      if (_.isError(result)) {
-        return done(result)
-      }
-      done(null, result)
-    }
-  }
-}
-
-module.exports.reducify = reducify
-
-function reducifyAll (source, methodList) {
-  let target = source
-  if (!_.isEmpty(methodList)) {
-    target = _.pick(source, methodList)
-  }
-  return _.mapValues(target, reducify)
-}
-
-module.exports.reducifyAll = reducifyAll
-
-function mockReducer (reducer, acc) {
-  const pcb = Promise.promisify(reducer)
-  return pcb(acc).then(val => ({ value: val }))
-}
-
-module.exports.mockReducer = mockReducer
 
 const createTransform = require('../transform-expression').create
 

--- a/packages/data-point/lib/helpers/helpers.test.js
+++ b/packages/data-point/lib/helpers/helpers.test.js
@@ -1,78 +1,7 @@
 /* eslint-env jest */
 'use strict'
 
-const _ = require('lodash')
 const helpers = require('./helpers')
-
-describe('helpers.reducify', () => {
-  test('pass simple', done => {
-    const rpick = helpers.reducify(_.pick)
-    const input = ['a', 'c']
-    const acc = {
-      value: { a: 1, b: 2, c: 3 }
-    }
-    rpick(input)(acc, (err, value) => {
-      /* eslint handle-callback-err: 0 */
-      expect(value).toEqual({ a: 1, c: 3 })
-      done()
-    })
-  })
-
-  test('pass error', done => {
-    const rTest = helpers.reducify(() => {
-      return new Error('testerror')
-    })
-    rTest()({}, (err, value) => {
-      /* eslint handle-callback-err: 0 */
-      expect(err).toBeInstanceOf(Error)
-      done()
-    })
-  })
-})
-
-describe('helpers.reducifyAll', () => {
-  test('reducify all keys', done => {
-    const rLodash = helpers.reducifyAll(_)
-    const input = ['a', 'c']
-    const acc = {
-      value: { a: 1, b: 2, c: 3 }
-    }
-    const keys = Object.keys(rLodash)
-    expect(keys.length).toBeGreaterThan(10)
-    rLodash.pick(input)(acc, (err, value) => {
-      /* eslint handle-callback-err: 0 */
-      expect(value).toEqual({ a: 1, c: 3 })
-      done()
-    })
-  })
-
-  test('reducify specificy keys', done => {
-    const rLodash = helpers.reducifyAll(_, ['pick', 'map', 'find'])
-    const input = ['a', 'c']
-    const acc = {
-      value: { a: 1, b: 2, c: 3 }
-    }
-    const keys = Object.keys(rLodash)
-    expect(keys).toEqual(['pick', 'map', 'find'])
-    rLodash.pick(input)(acc, (err, value) => {
-      /* eslint handle-callback-err: 0 */
-      expect(value).toEqual({ a: 1, c: 3 })
-      done()
-    })
-  })
-})
-
-describe('helpers.mockReducer', () => {
-  test('test reducerTest', () => {
-    const reducerTest = a => (acc, done) => {
-      done(null, acc.value * a)
-    }
-
-    return helpers.mockReducer(reducerTest(2), { value: 100 }).then(result => {
-      expect(result.value).toBe(200)
-    })
-  })
-})
 
 describe('helpers.createAccumulator', () => {
   test('It should assign value', () => {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Remove unused functions from `helpers.js`

<!-- Why are these changes necessary? -->
**Why**: The `reducify`, `reducifyAll`, and `mockReducer` functions were not being used

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation n/a
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
