### PR TITLE
Remove higher order reducer section from readme

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -28,7 +28,6 @@ npm install --save data-point
   - [PathReducer](#path-reducer)
   - [FunctionReducer](#function-reducer)
   - [ObjectReducer](#object-reducer)
-  - [Higher Order Reducers](#higher-order-reducers)
   - [EntityReducer](#entity-reducer)
   - [Collection Mapping](#reducer-collection-mapping)
 - [Entities](#entities)
@@ -736,45 +735,6 @@ Each of the TransformExpressions might also contain more ObjectReducers (which m
   }
   ```
 </details>
-
-
-### <a name="higher-order-reducers">Higher Order Reducers</a>
-
-Higher Order Reducers are expected to be [Higher-order Functions](https://en.wikipedia.org/wiki/Higher-order_function). This means that a higher order reducer **MUST** return a [FunctionReducer](#function-reducer).
-
-```js
-// sync
-const name = (param1, param2, ...) => (acc:Accumulator) => {
-  return newValue
-}
-// async via promise
-const name = (param1, param2, ...) => (acc:Accumulator) => {
-  return Promise.resolve(newValue)
-}
-// async via callback
-const name = (param1, param2, ...) => (acc:Accumulator, next:function) => {
-  next(error:Error, newValue:*)
-}
-```
-
-<details>
-  <summary>Higher Order Reducer Example</summary>
-  
-  ```js
-  const addStr = (value) => (acc) => {
-    return acc.value + value
-  }
-  
-  dataPoint
-    .transform(addStr(' World!!'), 'Hello')
-    .then((acc) => {
-      assert.equal(acc.value, 'Hello World!!')
-    })
-  ```
-</details>
-
-
-Example at: [examples/reducer-function-closure.js](examples/reducer-function-closure.js)
 
 ### <a name="entity-reducer">EntityReducer</a>
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Remove "Higher Order Reducer" section from readme.

<!-- Why are these changes necessary? -->
**Why**: This section is confusing. It seems like it's describing some DataPoint feature, but it's really just describing higher order functions in JavaScript -- and DataPoint itself does not provide any special functionality for supporting them.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests n/a
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->