### PR TITLE
Remove references to transform

### DIFF
--- a/packages/data-point-express/lib/inspector-middleware.js
+++ b/packages/data-point-express/lib/inspector-middleware.js
@@ -25,7 +25,7 @@ function dataPointInspectRoute (dataPoint, req, res, next) {
     pathname
   })
 
-  Middleware.resolveTransform(dataPoint, entityId, transformOptions, res, value)
+  Middleware.resolveReducer(dataPoint, entityId, transformOptions, res, value)
 }
 
 function create (dataPoint) {

--- a/packages/data-point-express/lib/middleware.js
+++ b/packages/data-point-express/lib/middleware.js
@@ -42,15 +42,9 @@ function createErrorMessage (err) {
   }
 }
 
-function resolveTransform (
-  dataPoint,
-  transform,
-  options,
-  res,
-  initialValue = {}
-) {
+function resolveReducer (dataPoint, reducer, options, res, initialValue = {}) {
   dataPoint
-    .transform(transform, initialValue, options)
+    .transform(reducer, initialValue, options)
     .then(acc => {
       if (typeof acc.value === 'string') {
         res.send(acc.value)
@@ -66,7 +60,7 @@ function resolveTransform (
 
 module.exports = {
   getErrorOwnKeys,
-  resolveTransform,
+  resolveReducer,
   createErrorMessage,
   buildTransformOptions
 }

--- a/packages/data-point-express/lib/middleware.test.js
+++ b/packages/data-point-express/lib/middleware.test.js
@@ -167,7 +167,7 @@ describe('createErrorMessage', () => {
   })
 })
 
-describe('resolveTransform', () => {
+describe('resolveReducer', () => {
   let dataPoint
   beforeAll(() => {
     dataPoint = DataPoint.create({
@@ -184,7 +184,7 @@ describe('resolveTransform', () => {
   test('it should resolve text response', done => {
     const app = new Express()
     app.get('/test', (req, res) => {
-      return Middleware.resolveTransform(dataPoint, 'transform:string', {}, res)
+      return Middleware.resolveReducer(dataPoint, 'transform:string', {}, res)
     })
     request(app)
       .get('/test')
@@ -199,7 +199,7 @@ describe('resolveTransform', () => {
   test('it should resolve object response', done => {
     const app = new Express()
     app.get('/test', (req, res) => {
-      return Middleware.resolveTransform(dataPoint, 'transform:object', {}, res)
+      return Middleware.resolveReducer(dataPoint, 'transform:object', {}, res)
     })
     request(app)
       .get('/test')
@@ -216,7 +216,7 @@ describe('resolveTransform', () => {
   test('it should resolve passing initial value', done => {
     const app = new Express()
     app.get('/test', (req, res) => {
-      return Middleware.resolveTransform(
+      return Middleware.resolveReducer(
         dataPoint,
         'transform:value',
         {},

--- a/packages/data-point-express/lib/route-middleware.js
+++ b/packages/data-point-express/lib/route-middleware.js
@@ -8,7 +8,7 @@ function dataPointEntityRoute (dataPoint, entityId, req, res, next) {
     routeRequestType: 'api',
     pathname
   })
-  Middleware.resolveTransform(dataPoint, entityId, transformOptions, res)
+  Middleware.resolveReducer(dataPoint, entityId, transformOptions, res)
 }
 
 function create (dataPoint, entityId) {

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -2878,7 +2878,7 @@ function create(spec:Object):Object
 This is where your entity resolution logic is to be implemented. It follows the following syntax: 
 
 ```js
-function resolve(acc:Accumulator, resolveTransform:function):Promise<Accumulator>
+function resolve(acc:Accumulator, resolveReducer:function):Promise<Accumulator>
 ```
 
 <details>
@@ -2910,14 +2910,14 @@ function resolve(acc:Accumulator, resolveTransform:function):Promise<Accumulator
   /**
   * Resolve entity
   * @param {Accumulator} accumulator
-  * @param {function} resolveTransform
+  * @param {function} resolveReducer
   * @return {Promise}
   */
-  function resolve (accumulator, resolveTransform) {
+  function resolve (accumulator, resolveReducer) {
     // get Entity Spec
     const spec = accumulator.reducer.spec
     // resolve 'spec.value' reducer against accumulator
-    return resolveTransform(accumulator, spec.value)
+    return resolveReducer(accumulator, spec.value)
       .then((acc) => {
         // execute lodash template against accumulator value
         const output = spec.template(acc.value)

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -29,6 +29,7 @@ npm install --save data-point
   - [ObjectReducer](#object-reducer)
   - [Higher Order Reducers](#higher-order-reducers)
   - [EntityReducer](#entity-reducer)
+  - [ListReducer](#list-reducer)
   - [Collection Mapping](#reducer-collection-mapping)
 - [Entities](#entities)
   - [dataPoint.addEntities](#api-data-point-add-entities)

--- a/packages/data-point/examples/custom-entity-type.js
+++ b/packages/data-point/examples/custom-entity-type.js
@@ -22,15 +22,15 @@ function create (spec, id) {
 /**
  * Resolve entity
  * @param {Accumulator} accumulator
- * @param {function} resolveTransform
+ * @param {Function} resolveReducer
  * @return {Promise}
  */
-function resolve (accumulator, resolveTransform) {
+function resolve (accumulator, resolveReducer) {
   // get Entity Spec
   const spec = accumulator.reducer.spec
   // resolve 'spec.value' reducer
   // against accumulator
-  return resolveTransform(accumulator, spec.value).then(acc => {
+  return resolveReducer(accumulator, spec.value).then(acc => {
     // execute lodash template against
     // accumulator value
     const output = spec.template(acc.value)

--- a/packages/data-point/examples/entity-request-string-template.js
+++ b/packages/data-point/examples/entity-request-string-template.js
@@ -48,7 +48,7 @@ const options = {
   locals: { name: 'nodejs' }
 }
 
-// here we pass options (thrid argument to transform)
+// here we pass options (third argument to transform)
 dataPoint.transform('request:getOrgInfoFromLocals', true, options).then(acc => {
   console.log(acc.value)
   // entire result from https://api.github.com/orgs/nodejs

--- a/packages/data-point/lib/core/transform.js
+++ b/packages/data-point/lib/core/transform.js
@@ -21,9 +21,9 @@ function resolve (manager, reducerSource, value, options) {
     values: manager.values.getStore()
   })
 
-  const transform = Reducer.create(reducerSource)
+  const reducer = Reducer.create(reducerSource)
 
-  return Reducer.resolve(manager, context, transform)
+  return Reducer.resolve(manager, context, reducer)
 }
 
 function transform (manager, reducerSource, value, options, done) {

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -4,18 +4,18 @@
 const ResolveEntity = require('./resolve')
 const createReducerEntity = require('../../reducer-entity').create
 const createReducer = require('../../reducer').create
-const resolveTransform = require('../../reducer').resolve
+const resolveReducer = require('../../reducer').resolve
 
 const FixtureStore = require('../../../test/utils/fixture-store')
 const helpers = require('../../helpers')
 const utils = require('../../utils')
 
 let dataPoint
-let resolveTransformBound
+let resolveReducerBound
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransformBound = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 afterEach(() => {
@@ -36,7 +36,7 @@ describe('ResolveEntity.resolveErrorReducers', () => {
     return ResolveEntity.resolveErrorReducers(
       err,
       accumulator,
-      resolveTransformBound
+      resolveReducerBound
     )
       .catch(reason => reason)
       .then(acc => {
@@ -58,7 +58,7 @@ describe('ResolveEntity.resolveErrorReducers', () => {
     return ResolveEntity.resolveErrorReducers(
       err,
       accumulator,
-      resolveTransformBound
+      resolveReducerBound
     ).then(acc => {
       expect(acc.value).toEqual('pass')
     })
@@ -132,14 +132,14 @@ describe('ResolveEntity.resolveMiddleware', () => {
 })
 
 describe('ResolveEntity.resolveEntity', () => {
-  const defaultResolver = (acc, resolveTransform) => Promise.resolve(acc)
+  const defaultResolver = (acc, resolveReducer) => Promise.resolve(acc)
 
   const resolveEntity = (entityId, input, options, resolver) => {
     const racc = helpers.createAccumulator.call(null, input, options)
     const reducer = createReducerEntity(entityId)
     return ResolveEntity.resolveEntity(
       dataPoint,
-      resolveTransformBound,
+      resolveReducerBound,
       racc,
       reducer,
       resolver || defaultResolver
@@ -206,7 +206,7 @@ describe('ResolveEntity.resolve', () => {
     const reducer = createReducerEntity(entityId)
     return ResolveEntity.resolve(
       dataPoint,
-      resolveTransform,
+      resolveReducer,
       racc,
       reducer,
       resolver
@@ -214,7 +214,7 @@ describe('ResolveEntity.resolve', () => {
   }
 
   test('It should resolve as single entity', () => {
-    const resolver = (acc, resolveTransform) => {
+    const resolver = (acc, resolveReducer) => {
       const result = utils.set(acc, 'value', 'bar')
       return Promise.resolve(result)
     }
@@ -224,7 +224,7 @@ describe('ResolveEntity.resolve', () => {
   })
 
   test('It should resolve as collection', () => {
-    const resolver = (acc, resolveTransform) => {
+    const resolver = (acc, resolveReducer) => {
       const result = utils.set(acc, 'value', 'bar')
       return Promise.resolve(result)
     }
@@ -233,7 +233,7 @@ describe('ResolveEntity.resolve', () => {
     })
   })
   test('It should return undefined if accumulator is not Array', () => {
-    const resolver = (acc, resolveTransform) => {
+    const resolver = (acc, resolveReducer) => {
       return Promise.resolve(acc)
     }
     return resolve(resolver)('hash:asIs[]', {}).then(acc => {
@@ -248,7 +248,7 @@ describe('ResolveEntity.resolve', () => {
   })
 
   test('It should execute resolver if flag hasEmptyConditional is true and value is not empty', () => {
-    const resolver = (acc, resolveTransform) => {
+    const resolver = (acc, resolveReducer) => {
       const result = utils.set(acc, 'value', 'bar')
       return Promise.resolve(result)
     }
@@ -259,7 +259,7 @@ describe('ResolveEntity.resolve', () => {
 
   test('It should execute resolver only on non empty items of collection if hasEmptyConditional is set', () => {
     let count = 0
-    const resolver = (acc, resolveTransform) => {
+    const resolver = (acc, resolveReducer) => {
       const result = utils.set(acc, 'value', count++)
       return Promise.resolve(result)
     }

--- a/packages/data-point/lib/entity-types/entity-collection/factory.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.js
@@ -17,7 +17,7 @@ const modifierKeys = ['filter', 'map', 'find']
 function createCompose (composeParse) {
   return composeParse.map(modifier => {
     return _.assign({}, modifier, {
-      transform: createReducer(modifier.spec)
+      reducer: createReducer(modifier.spec)
     })
   })
 }

--- a/packages/data-point/lib/entity-types/entity-collection/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.test.js
@@ -23,7 +23,7 @@ describe('parse loose modifiers', () => {
 
     expect(result.compose).toBeInstanceOf(Array)
     expect(result.compose[0]).toHaveProperty('type', 'map')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerPath')
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerPath')
   })
 
   test('modelFactory#create default', () => {
@@ -48,7 +48,7 @@ describe('parse compose modifier', () => {
 
     expect(result.compose).toBeInstanceOf(Array)
     expect(result.compose[0]).toHaveProperty('type', 'map')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerPath')
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerPath')
   })
 
   test('throw error if compose is not an array', () => {

--- a/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
@@ -9,7 +9,7 @@ const testData = require('../../../test/data.json')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -22,12 +22,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveCollectionEntity(accumulator, resolveTransform)
+  return resolveCollectionEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 beforeEach(() => {

--- a/packages/data-point/lib/entity-types/entity-control/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-control/resolve.js
@@ -6,10 +6,10 @@ const Promise = require('bluebird')
  *
  * @param {any} caseStatements
  * @param {any} acc
- * @param {any} resolveTransform
+ * @param {any} resolveReducer
  * @returns
  */
-function getMatchingCaseStatement (caseStatements, acc, resolveTransform) {
+function getMatchingCaseStatement (caseStatements, acc, resolveReducer) {
   return Promise.reduce(
     caseStatements,
     (result, statement) => {
@@ -22,7 +22,7 @@ function getMatchingCaseStatement (caseStatements, acc, resolveTransform) {
         return Promise.reject(err)
       }
 
-      return resolveTransform(acc, statement.case).then(res => {
+      return resolveReducer(acc, statement.case).then(res => {
         return res.value ? statement : false
       })
     },
@@ -38,18 +38,18 @@ function getMatchingCaseStatement (caseStatements, acc, resolveTransform) {
 }
 module.exports.getMatchingCaseStatement = getMatchingCaseStatement
 
-function resolve (acc, resolveTransform) {
+function resolve (acc, resolveReducer) {
   const selectControl = acc.reducer.spec.select
   const caseStatements = selectControl.cases
   const defaultTransform = selectControl.default
 
-  return getMatchingCaseStatement(caseStatements, acc, resolveTransform).then(
+  return getMatchingCaseStatement(caseStatements, acc, resolveReducer).then(
     caseStatement => {
       if (caseStatement) {
-        return resolveTransform(acc, caseStatement.do)
+        return resolveReducer(acc, caseStatement.do)
       }
 
-      return resolveTransform(acc, defaultTransform)
+      return resolveReducer(acc, defaultTransform)
     }
   )
 }

--- a/packages/data-point/lib/entity-types/entity-control/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-control/resolve.test.js
@@ -9,7 +9,7 @@ const testData = require('../../../test/data.json')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -22,12 +22,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveControlEntity(accumulator, resolveTransform)
+  return resolveControlEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 describe('entity-control#resolve', () => {

--- a/packages/data-point/lib/entity-types/entity-entry/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-entry/resolve.js
@@ -3,11 +3,11 @@
 const _ = require('lodash')
 const utils = require('../../utils')
 
-function resolve (acc, resolveTransform) {
+function resolve (acc, resolveReducer) {
   const contextTransform = acc.reducer.spec.value
   let racc = acc
   racc = utils.set(acc, 'value', _.defaultTo(acc.value, {}))
-  return resolveTransform(racc, contextTransform)
+  return resolveReducer(racc, contextTransform)
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-entry/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-entry/resolve.test.js
@@ -9,7 +9,7 @@ const testData = require('../../../test/data.json')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -22,12 +22,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveEntryEntity(accumulator, resolveTransform)
+  return resolveEntryEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 describe('Entry.resolve', () => {

--- a/packages/data-point/lib/entity-types/entity-hash/factory.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.js
@@ -19,24 +19,24 @@ const modifierKeys = ['omitKeys', 'pickKeys', 'mapKeys', 'addValues', 'addKeys']
 function createCompose (composeParse) {
   return composeParse.map(modifier => {
     let spec
-    let transform
+    let reducer
     switch (modifier.type) {
       case 'addValues':
         spec = _.defaultTo(modifier.spec, {})
-        transform = deepFreeze(spec)
+        reducer = deepFreeze(spec)
         break
       case 'omitKeys':
       case 'pickKeys':
         spec = _.defaultTo(modifier.spec, [])
-        transform = Object.freeze(spec.slice(0))
+        reducer = Object.freeze(spec.slice(0))
         break
       case 'mapKeys':
       case 'addKeys':
-        transform = createReducerObject(createReducer, modifier.spec)
+        reducer = createReducerObject(createReducer, modifier.spec)
     }
 
     return Object.assign({}, modifier, {
-      transform
+      reducer
     })
   })
 }

--- a/packages/data-point/lib/entity-types/entity-hash/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.test.js
@@ -24,7 +24,7 @@ describe('factory#parse loose modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'mapKeys')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerObject')
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerObject')
   })
   test('factory#addKeys', () => {
     const result = factory.create({
@@ -34,7 +34,7 @@ describe('factory#parse loose modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'addKeys')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerObject')
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerObject')
   })
   test('factory#omitKeys', () => {
     const result = factory.create({
@@ -42,7 +42,7 @@ describe('factory#parse loose modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'omitKeys')
-    expect(result.compose[0].transform).toEqual(['a'])
+    expect(result.compose[0].reducer).toEqual(['a'])
   })
   test('factory#pickKeys', () => {
     const result = factory.create({
@@ -50,7 +50,7 @@ describe('factory#parse loose modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'pickKeys')
-    expect(result.compose[0].transform).toEqual(['a'])
+    expect(result.compose[0].reducer).toEqual(['a'])
   })
 })
 
@@ -103,7 +103,7 @@ describe('factory#parse composed modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'mapKeys')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerObject')
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerObject')
   })
   test('factory#multiple modifiers', () => {
     const result = factory.create({
@@ -125,20 +125,20 @@ describe('factory#parse composed modifiers', () => {
     })
 
     expect(result.compose[0]).toHaveProperty('type', 'addKeys')
-    expect(result.compose[0].transform).toHaveProperty('type', 'ReducerObject')
-    expect(result.compose[0].transform.props[0].path).toEqual(['a'])
-    expect(result.compose[0].transform.props[0].transform).toHaveProperty(
+    expect(result.compose[0].reducer).toHaveProperty('type', 'ReducerObject')
+    expect(result.compose[0].reducer.props[0].path).toEqual(['a'])
+    expect(result.compose[0].reducer.props[0].reducer).toHaveProperty(
       'type',
       'ReducerPath'
     )
     expect(result.compose[1]).toHaveProperty('type', 'mapKeys')
-    expect(result.compose[1].transform).toHaveProperty('type', 'ReducerObject')
-    expect(result.compose[1].transform.props[0].path).toEqual(['a'])
-    expect(result.compose[1].transform.props[0].transform).toHaveProperty(
+    expect(result.compose[1].reducer).toHaveProperty('type', 'ReducerObject')
+    expect(result.compose[1].reducer.props[0].path).toEqual(['a'])
+    expect(result.compose[1].reducer.props[0].reducer).toHaveProperty(
       'type',
       'ReducerPath'
     )
     expect(result.compose[2]).toHaveProperty('type', 'omitKeys')
-    expect(result.compose[2].transform).toEqual(['a'])
+    expect(result.compose[2].reducer).toEqual(['a'])
   })
 })

--- a/packages/data-point/lib/entity-types/entity-hash/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-hash/resolve.js
@@ -4,16 +4,16 @@ const _ = require('lodash')
 const Promise = require('bluebird')
 const utils = require('../../utils')
 
-function resolveMapKeys (accumulator, reducer, resolveTransform) {
-  return resolveTransform(accumulator, reducer).then(acc => {
+function resolveMapKeys (accumulator, reducer, resolveReducer) {
+  return resolveReducer(accumulator, reducer).then(acc => {
     return utils.set(accumulator, 'value', acc.value)
   })
 }
 
 module.exports.resolveMapKeys = resolveMapKeys
 
-function resolveAddKeys (accumulator, reducer, resolveTransform) {
-  return resolveTransform(accumulator, reducer).then(acc => {
+function resolveAddKeys (accumulator, reducer, resolveReducer) {
+  return resolveReducer(accumulator, reducer).then(acc => {
     return resolveAddValues(accumulator, acc.value)
   })
 }
@@ -79,7 +79,7 @@ const modifierFunctionMap = {
   addKeys: resolveAddKeys
 }
 
-function resolveCompose (accumulator, composeReducers, resolveTransform) {
+function resolveCompose (accumulator, composeReducers, resolveReducer) {
   if (composeReducers.length === 0) {
     return Promise.resolve(accumulator)
   }
@@ -90,15 +90,15 @@ function resolveCompose (accumulator, composeReducers, resolveTransform) {
       const modifierFunction = modifierFunctionMap[modifierSpec.type]
       return modifierFunction(
         resultContext,
-        modifierSpec.transform,
-        resolveTransform
+        modifierSpec.reducer,
+        resolveReducer
       )
     },
     accumulator
   )
 }
 
-function resolve (acc, resolveTransform) {
+function resolve (acc, resolveReducer) {
   const entity = acc.reducer.spec
 
   // if there is nothing to do, lets just move on
@@ -106,9 +106,9 @@ function resolve (acc, resolveTransform) {
     return Promise.resolve(acc)
   }
 
-  return resolveTransform(acc, entity.value)
+  return resolveReducer(acc, entity.value)
     .then(itemContext => validateAsObject(itemContext))
-    .then(acc => resolveCompose(acc, entity.compose, resolveTransform))
+    .then(acc => resolveCompose(acc, entity.compose, resolveReducer))
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-hash/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/resolve.test.js
@@ -9,7 +9,7 @@ const testData = require('../../../test/data.json')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -22,12 +22,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveHashEntity(accumulator, resolveTransform)
+  return resolveHashEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 describe('entity.hash.resolve', () => {

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -51,16 +51,16 @@ module.exports.getRequestOptions = getRequestOptions
 /**
  * Resolve options object
  * @param {Accumulator} acc
- * @param {function} resolveTransform
+ * @param {function} resolveReducer
  */
-function resolveOptions (acc, resolveTransform) {
+function resolveOptions (acc, resolveReducer) {
   const options = acc.reducer.spec.options
   const transformOptionKeys = acc.reducer.spec.transformOptionKeys
   // iterate over each option transform key
   return Promise.reduce(
     transformOptionKeys,
     (newOptions, key) => {
-      return resolveTransform(acc, key.transform).then(res => {
+      return resolveReducer(acc, key.transform).then(res => {
         return fp.set(key.path, res.value, newOptions)
       })
     },
@@ -82,7 +82,7 @@ function inspect (acc) {
 }
 module.exports.inspect = inspect
 
-function resolveBeforeRequest (acc, resolveTransform) {
+function resolveBeforeRequest (acc, resolveReducer) {
   const entity = acc.reducer.spec
 
   let options = getRequestOptions(acc.options)
@@ -97,14 +97,14 @@ function resolveBeforeRequest (acc, resolveTransform) {
   }
 
   const beforeRequestAcc = utils.set(acc, 'value', options)
-  return resolveTransform(beforeRequestAcc, entity.beforeRequest).then(result =>
+  return resolveReducer(beforeRequestAcc, entity.beforeRequest).then(result =>
     utils.set(acc, 'options', result.value)
   )
 }
 
 module.exports.resolveBeforeRequest = resolveBeforeRequest
 
-function resolveRequest (acc, resolveTransform) {
+function resolveRequest (acc, resolveReducer) {
   inspect(acc)
   return rp(acc.options)
     .then(result => utils.set(acc, 'value', result))
@@ -135,14 +135,14 @@ function resolveRequest (acc, resolveTransform) {
 
 module.exports.resolveRequest = resolveRequest
 
-function resolve (acc, resolveTransform) {
+function resolve (acc, resolveReducer) {
   const entity = acc.reducer.spec
   return Promise.resolve(acc)
-    .then(itemContext => resolveTransform(itemContext, entity.value))
-    .then(itemContext => resolveOptions(itemContext, resolveTransform))
+    .then(itemContext => resolveReducer(itemContext, entity.value))
+    .then(itemContext => resolveOptions(itemContext, resolveReducer))
     .then(itemContext => resolveUrl(itemContext))
-    .then(itemContext => resolveBeforeRequest(itemContext, resolveTransform))
-    .then(itemContext => resolveRequest(itemContext, resolveTransform))
+    .then(itemContext => resolveBeforeRequest(itemContext, resolveReducer))
+    .then(itemContext => resolveRequest(itemContext, resolveReducer))
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -16,7 +16,7 @@ const FixtureStore = require('../../../test/utils/fixture-store')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -26,7 +26,7 @@ function transform (entityId, value, options) {
     values
   })
   const acc = Object.assign({}, accumulator, options)
-  return Resolve.resolve(acc, resolveTransform)
+  return Resolve.resolve(acc, resolveReducerBound)
 }
 
 let locals
@@ -47,7 +47,7 @@ beforeAll(() => {
     itemPath: '/source1'
   })
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
   values = dataPoint.values.getStore()
 })
 
@@ -109,7 +109,7 @@ describe('resolveOptions', () => {
       },
       transformOptionKeys: []
     })
-    return Resolve.resolveOptions(acc, resolveTransform).then(result => {
+    return Resolve.resolveOptions(acc, resolveReducerBound).then(result => {
       expect(result.options).toEqual({
         port: 80
       })
@@ -137,7 +137,7 @@ describe('resolveOptions', () => {
         }
       }
     }
-    return Resolve.resolveOptions(acc, resolveTransform).then(result => {
+    return Resolve.resolveOptions(acc, resolveReducerBound).then(result => {
       expect(result.options).toEqual({
         port: 80,
         qs: {

--- a/packages/data-point/lib/entity-types/entity-schema/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-schema/resolve.js
@@ -24,10 +24,10 @@ function validateContext (acc) {
 
 module.exports.validateContext = validateContext
 
-function resolve (acc, resolveTransform) {
+function resolve (acc, resolveReducer) {
   const value = acc.reducer.spec.value
 
-  return resolveTransform(acc, value).then(racc => {
+  return resolveReducer(acc, value).then(racc => {
     return validateContext(racc)
   })
 }

--- a/packages/data-point/lib/entity-types/entity-schema/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-schema/resolve.test.js
@@ -8,7 +8,7 @@ const FixtureStore = require('../../../test/utils/fixture-store')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -21,12 +21,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveSchemaEntity(accumulator, resolveTransform)
+  return resolveSchemaEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 describe('schema.resolve', function () {

--- a/packages/data-point/lib/entity-types/entity-transform/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-transform/resolve.js
@@ -1,8 +1,8 @@
 'use strict'
 
-function resolve (accumulator, resolveTransform) {
+function resolve (accumulator, resolveReducer) {
   const entity = accumulator.reducer.spec
-  return resolveTransform(accumulator, entity.value)
+  return resolveReducer(accumulator, entity.value)
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-transform/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-transform/resolve.test.js
@@ -8,7 +8,7 @@ const FixtureStore = require('../../../test/utils/fixture-store')
 const helpers = require('../../helpers')
 
 let dataPoint
-let resolveTransform
+let resolveReducerBound
 
 function transform (entityId, value, options) {
   const reducer = dataPoint.entities.get(entityId)
@@ -21,12 +21,12 @@ function transform (entityId, value, options) {
       options
     )
   )
-  return resolveTransformEntity(accumulator, resolveTransform)
+  return resolveTransformEntity(accumulator, resolveReducerBound)
 }
 
 beforeAll(() => {
   dataPoint = FixtureStore.create()
-  resolveTransform = helpers.createResolveTransform(dataPoint)
+  resolveReducerBound = helpers.createReducerResolver(dataPoint)
 })
 
 describe('entity.transform.value', () => {

--- a/packages/data-point/lib/helpers/helpers.js
+++ b/packages/data-point/lib/helpers/helpers.js
@@ -73,7 +73,7 @@ module.exports.createReducerResolver = createReducerResolver
  * @param {*} data
  * @returns {boolean}
  */
-function isTransform (data) {
+function isReducer (data) {
   return (
     data instanceof ReducerEntity ||
     data instanceof ReducerFunction ||
@@ -83,4 +83,4 @@ function isTransform (data) {
   )
 }
 
-module.exports.isTransform = isTransform
+module.exports.isReducer = isReducer

--- a/packages/data-point/lib/helpers/helpers.js
+++ b/packages/data-point/lib/helpers/helpers.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 const Promise = require('bluebird')
-const resolveTransform = require('../reducer').resolve
+const resolveReducer = require('../reducer').resolve
 const AccumulatorFactory = require('../accumulator/factory')
 
 const ReducerEntity = require('../reducer-entity/factory').ReducerEntity
@@ -10,6 +10,12 @@ const ReducerFunction = require('../reducer-function/factory').ReducerFunction
 const ReducerList = require('../reducer-list/factory').ReducerList
 const ReducerObject = require('../reducer-object/factory').ReducerObject
 const ReducerPath = require('../reducer-path/factory').ReducerPath
+
+module.exports.createReducer = require('../reducer').create
+
+module.exports.createEntity = require('../entity-types/base-entity').create
+
+module.exports.resolveEntity = require('../entity-types/base-entity/resolve').resolve
 
 function reducify (method) {
   return function () {
@@ -44,19 +50,6 @@ function mockReducer (reducer, acc) {
 
 module.exports.mockReducer = mockReducer
 
-const createReducer = require('../reducer').create
-
-// this is named createTransform for backwards compatibility
-module.exports.createTransform = createReducer
-
-const createEntity = require('../entity-types/base-entity').create
-
-module.exports.createEntity = createEntity
-
-const resolveEntity = require('../entity-types/base-entity/resolve').resolve
-
-module.exports.resolveEntity = resolveEntity
-
 function createAccumulator (value, options) {
   return AccumulatorFactory.create(
     Object.assign(
@@ -70,11 +63,11 @@ function createAccumulator (value, options) {
 
 module.exports.createAccumulator = createAccumulator
 
-function createResolveTransform (dataPoint) {
-  return resolveTransform.bind(null, dataPoint)
+function createReducerResolver (dataPoint) {
+  return resolveReducer.bind(null, dataPoint)
 }
 
-module.exports.createResolveTransform = createResolveTransform
+module.exports.createReducerResolver = createReducerResolver
 
 /**
  * @param {*} data

--- a/packages/data-point/lib/helpers/helpers.test.js
+++ b/packages/data-point/lib/helpers/helpers.test.js
@@ -94,10 +94,10 @@ describe('helpers.createAccumulator', () => {
   })
 })
 
-describe('helpers.createResolveTransform', () => {
+describe('helpers.createReducerResolver', () => {
   test('It should partially apply dataPoint to method', () => {
-    const resolveTransform = helpers.createResolveTransform({})
-    expect(resolveTransform.length).toEqual(2)
+    const resolveReducerBound = helpers.createReducerResolver({})
+    expect(resolveReducerBound.length).toEqual(2)
   })
 })
 

--- a/packages/data-point/lib/helpers/helpers.test.js
+++ b/packages/data-point/lib/helpers/helpers.test.js
@@ -101,16 +101,16 @@ describe('helpers.createReducerResolver', () => {
   })
 })
 
-describe('helpers.isTransform', () => {
+describe('helpers.isReducer', () => {
   test('It should return true for reducers', () => {
-    expect(helpers.isTransform()).toBe(false)
-    expect(helpers.isTransform({})).toBe(false)
-    expect(helpers.isTransform([])).toBe(false)
-    expect(helpers.isTransform({ type: 'ReducerPath' })).toBe(false)
-    expect(helpers.isTransform(new ReducerEntity())).toBe(true)
-    expect(helpers.isTransform(new ReducerFunction())).toBe(true)
-    expect(helpers.isTransform(new ReducerList())).toBe(true)
-    expect(helpers.isTransform(new ReducerObject())).toBe(true)
-    expect(helpers.isTransform(new ReducerPath())).toBe(true)
+    expect(helpers.isReducer()).toBe(false)
+    expect(helpers.isReducer({})).toBe(false)
+    expect(helpers.isReducer([])).toBe(false)
+    expect(helpers.isReducer({ type: 'ReducerPath' })).toBe(false)
+    expect(helpers.isReducer(new ReducerEntity())).toBe(true)
+    expect(helpers.isReducer(new ReducerFunction())).toBe(true)
+    expect(helpers.isReducer(new ReducerList())).toBe(true)
+    expect(helpers.isReducer(new ReducerObject())).toBe(true)
+    expect(helpers.isReducer(new ReducerPath())).toBe(true)
   })
 })

--- a/packages/data-point/lib/reducer-list/resolve.js
+++ b/packages/data-point/lib/reducer-list/resolve.js
@@ -5,19 +5,19 @@ const partial = require('lodash/partial')
 
 /**
  * @param {Object} manager
- * @param {Function} resolveTransform
+ * @param {Function} resolveReducer
  * @param {Accumulator} accumulator
  * @param {ReducerList} reducerList
  * @returns {Promise<Accumulator>}
  */
-function resolve (manager, resolveTransform, accumulator, reducerList) {
+function resolve (manager, resolveReducer, accumulator, reducerList) {
   if (reducerList.reducers.length === 0) {
     return Promise.resolve(accumulator)
   }
 
   const result = Promise.reduce(
     reducerList.reducers,
-    partial(resolveTransform, manager),
+    partial(resolveReducer, manager),
     accumulator
   )
 

--- a/packages/data-point/lib/reducer-object/__snapshots__/factory.test.js.snap
+++ b/packages/data-point/lib/reducer-object/__snapshots__/factory.test.js.snap
@@ -6,7 +6,7 @@ Array [
     "path": Array [
       "a1",
     ],
-    "transform": ReducerPath {
+    "reducer": ReducerPath {
       "asCollection": true,
       "body": [Function],
       "name": "a",
@@ -18,7 +18,7 @@ Array [
       "b1",
       "a2",
     ],
-    "transform": ReducerList {
+    "reducer": ReducerList {
       "reducers": Array [
         ReducerPath {
           "asCollection": false,
@@ -39,13 +39,13 @@ Array [
       "b1",
       "b2",
     ],
-    "transform": ReducerObject {
+    "reducer": ReducerObject {
       "props": Array [
         Object {
           "path": Array [
             "a3",
           ],
-          "transform": ReducerEntity {
+          "reducer": ReducerEntity {
             "asCollection": false,
             "entityType": "transform",
             "hasEmptyConditional": false,
@@ -59,7 +59,7 @@ Array [
           "path": Array [
             "b3",
           ],
-          "transform": ReducerPath {
+          "reducer": ReducerPath {
             "asCollection": false,
             "body": [Function],
             "name": "b1.b2.b3",

--- a/packages/data-point/lib/reducer-object/factory.js
+++ b/packages/data-point/lib/reducer-object/factory.js
@@ -30,26 +30,26 @@ module.exports.isObject = isObject
  * @param {Function} createReducer
  * @param {Object} source
  * @param {Array} path
- * @param {Array} reducerProps
+ * @param {Array} props
  * @returns {Array}
  */
-function getReducerProps (createReducer, source, path = [], reducerProps = []) {
+function getReducerProps (createReducer, source, path = [], props = []) {
   for (let key of Object.keys(source)) {
     const value = source[key]
     const fullPath = path.concat(key)
     if (isPlainObject(value)) {
       // NOTE: recursive call
-      getReducerProps(createReducer, value, fullPath, reducerProps)
+      getReducerProps(createReducer, value, fullPath, props)
       continue
     }
 
-    reducerProps.push({
+    props.push({
       path: fullPath,
-      transform: createReducer(value)
+      reducer: createReducer(value)
     })
   }
 
-  return reducerProps
+  return props
 }
 
 module.exports.getReducerProps = getReducerProps

--- a/packages/data-point/lib/reducer-object/resolve.js
+++ b/packages/data-point/lib/reducer-object/resolve.js
@@ -4,20 +4,21 @@ const utils = require('../utils')
 
 /**
  * @param {Object} manager
- * @param {Function} resolveTransform
+ * @param {Function} resolveReducer
  * @param {Accumulator} accumulator
  * @param {ReducerObject} reducer
  * @returns {Promise<Accumulator>}
  */
-function resolve (manager, resolveTransform, accumulator, reducer) {
+function resolve (manager, resolveReducer, accumulator, reducer) {
   if (reducer.props.length === 0) {
     return Promise.resolve(accumulator)
   }
 
-  const props = Promise.map(reducer.props, ({ path, transform }) => {
-    return resolveTransform(manager, accumulator, transform).then(
-      ({ value }) => ({ path, value })
-    )
+  const props = Promise.map(reducer.props, ({ path, reducer }) => {
+    return resolveReducer(manager, accumulator, reducer).then(({ value }) => ({
+      path,
+      value
+    }))
   })
 
   return props

--- a/packages/data-point/lib/reducer-path/resolve.test.js
+++ b/packages/data-point/lib/reducer-path/resolve.test.js
@@ -4,8 +4,8 @@
 const reducerPath = require('./index')
 const AccumulatorFactory = require('../accumulator/factory')
 
-describe('resolve#transform.resolve', () => {
-  function resolve (value, rawReducer) {
+describe('ReducerPath#resolve', () => {
+  function resolve (value, reducerSource) {
     const locals = {
       a: ['testA']
     }
@@ -14,7 +14,7 @@ describe('resolve#transform.resolve', () => {
       locals
     })
 
-    return reducerPath.resolve(accumulator, reducerPath.create(rawReducer))
+    return reducerPath.resolve(accumulator, reducerPath.create(reducerSource))
   }
 
   test('resolve current value', () => {

--- a/packages/data-point/lib/reducer/resolve.js
+++ b/packages/data-point/lib/reducer/resolve.js
@@ -7,11 +7,11 @@ const resolveReducerList = require('../reducer-list').resolve
 
 /**
  * @param {Object} manager
- * @param {Function} resolveTransform
+ * @param {Function} resolveReducer
  * @param {string} reducerType
  * @returns
  */
-function getReducerFunction (manager, resolveTransform, reducerType) {
+function getReducerFunction (manager, resolveReducer, reducerType) {
   let resolver
 
   /* eslint indent: ["error", 2, { "SwitchCase": 1 }] */
@@ -24,15 +24,15 @@ function getReducerFunction (manager, resolveTransform, reducerType) {
       break
     case 'ReducerObject':
       // NOTE: recursive call
-      resolver = partial(resolveReducerObject, manager, resolveTransform)
+      resolver = partial(resolveReducerObject, manager, resolveReducer)
       break
     case 'ReducerEntity':
       // NOTE: recursive call
-      resolver = partial(resolveReducerEntity, manager, resolveTransform)
+      resolver = partial(resolveReducerEntity, manager, resolveReducer)
       break
     case 'ReducerList':
       // NOTE: recursive call
-      resolver = partial(resolveReducerList, manager, resolveTransform)
+      resolver = partial(resolveReducerList, manager, resolveReducer)
       break
     default:
       throw new Error(`Reducer type '${reducerType}' was not recognized`)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This is a follow up to PR #114. It replaces the word "transform" with the word "reducer".

<!-- Why are these changes necessary? -->
**Why**: We no longer have TransformExpressions, so functions like `createTransform` and `resolveTransform` were renamed to `createReducer` and `resolveReducer`

This also has a commit that's marked as a breaking change. #114 was a breaking change, but that was not communicated in any of the commits.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation n/a
- [ ] Tests n/a
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
