### PR TITLE
feat(data-point/reducer-path): Deprecate the $. syntax for path reducers

### DIFF
--- a/packages/data-point-service/lib/data-point-factory.test.js
+++ b/packages/data-point-service/lib/data-point-factory.test.js
@@ -8,7 +8,7 @@ describe('verify', () => {
     const result = DataPointFactory.verify({
       DataPoint,
       entities: {
-        'transform:foo': '$.'
+        'transform:foo': '$'
       }
     })
     expect(result).toEqual(result)
@@ -18,7 +18,7 @@ describe('verify', () => {
     expect(() => {
       DataPointFactory.verify({
         entities: {
-          'transform:foo': '$.'
+          'transform:foo': '$'
         }
       })
     }).toThrowError(/provided/)
@@ -38,7 +38,7 @@ describe('createDataPoint', () => {
     const dp = DataPointFactory.createDataPoint({
       DataPoint,
       entities: {
-        'transform:foo': '$.'
+        'transform:foo': '$'
       }
     })
 
@@ -51,7 +51,7 @@ describe('create', () => {
     return DataPointFactory.create({
       DataPoint,
       entities: {
-        'transform:foo': '$.'
+        'transform:foo': '$'
       }
     }).then(dp => {
       expect(dp).toHaveProperty('transform')

--- a/packages/data-point-service/lib/factory.test.js
+++ b/packages/data-point-service/lib/factory.test.js
@@ -168,7 +168,7 @@ describe('create', () => {
         isRequired: false
       },
       entities: {
-        'transform:foo': '$.'
+        'transform:foo': '$'
       }
     })
       .then(service => {
@@ -207,7 +207,7 @@ describe('create', () => {
         isRequired: true
       },
       entities: {
-        'transform:foo': '$.'
+        'transform:foo': '$'
       }
     })
       .then(service => {

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -303,12 +303,12 @@ PathReducer is a `string` value that extracts a path from the current [Accumulat
 
 | Option | Description |
 |:---|:---|
-| *$.* | Reference to current `accumulator.value`. |
+| *$* | Reference to current `accumulator.value`. |
 | *$..* | Gives you full access to current `accumulator`. |
 | *$path* | Simple Object path notation to extract a path from current `accumulator.value`. |
 | *$path[]* | Object path notation with trailing `[]` to extract a value from an array of objects at the `accumulator.value` for each. |
 
-#### <a name="root-path">Root path $.</a>
+#### <a name="root-path">Root path $</a>
 
 **EXAMPLES:**
 
@@ -328,7 +328,7 @@ PathReducer is a `string` value that extracts a path from the current [Accumulat
   }
 
   dataPoint
-    .transform('$.', input)
+    .transform('$', input)
     .then((acc) => {
       assert.equal(acc.value, input)
     })
@@ -1280,7 +1280,7 @@ Example at: [examples/entity-entry-basic.js](examples/entity-entry-basic.js)
   dataPoint.addEntities({
     'entry:foo': {
       before: isArray(),
-      value: '$.'
+      value: '$'
     }
   })
   

--- a/packages/data-point/examples/entity-entry-before.js
+++ b/packages/data-point/examples/entity-entry-before.js
@@ -13,7 +13,7 @@ const isArray = () => acc => {
 dataPoint.addEntities({
   'entry:foo': {
     before: isArray(),
-    value: '$.'
+    value: '$'
   }
 })
 

--- a/packages/data-point/lib/entity-types/base-entity/factory.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/factory.test.js
@@ -8,10 +8,10 @@ describe('factory.createBaseEntity', () => {
     const entity = createBaseEntity(
       FooEntity,
       {
-        before: '$.',
-        value: '$.',
-        error: '$.',
-        after: '$.'
+        before: '$',
+        value: '$',
+        error: '$',
+        after: '$'
       },
       'foo'
     )

--- a/packages/data-point/lib/reducer-types/reducer-function/factory.js
+++ b/packages/data-point/lib/reducer-types/reducer-function/factory.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash')
 
 const REDUCER_SYMBOL = require('../reducer-symbol')
@@ -59,6 +58,7 @@ function create (createReducer, source) {
   validateFunction(source)
   const reducer = new ReducerFunction()
   reducer.body = source
+
   return Object.freeze(reducer)
 }
 

--- a/packages/data-point/lib/reducer-types/reducer-path/factory.js
+++ b/packages/data-point/lib/reducer-types/reducer-path/factory.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash')
 
 const REDUCER_SYMBOL = require('../reducer-symbol')
@@ -86,7 +85,7 @@ module.exports.mapFromAccumulatorValue = mapFromAccumulatorValue
  * @returns {Function}
  */
 function getPathReducerFunction (jsonPath, asCollection) {
-  if (jsonPath === '.' || _.isEmpty(jsonPath)) {
+  if (jsonPath === '$' || _.isEmpty(jsonPath)) {
     return getAccumulatorValue
   }
 
@@ -112,7 +111,7 @@ function create (createReducer, source) {
   const reducer = new ReducerPath()
 
   reducer.asCollection = source.slice(-2) === '[]'
-  reducer.name = (source.substr(1) || '.').replace(/\[]$/, '')
+  reducer.name = (source.substr(1) || '$').replace(/\[]$/, '')
   reducer.body = getPathReducerFunction(reducer.name, reducer.asCollection)
 
   return Object.freeze(reducer)

--- a/packages/data-point/lib/reducer-types/reducer-path/factory.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-path/factory.test.js
@@ -5,7 +5,7 @@ const createReducer = require('../index').create
 
 it('reducer/reducer-path#isType', () => {
   expect(factory.isType('#a')).not.toBe('is not path')
-  expect(factory.isType('$.')).toBeTruthy()
+  expect(factory.isType('$')).toBeTruthy()
 })
 
 describe('ReducerPath getters', () => {
@@ -73,7 +73,7 @@ describe('reducer/reducer-path#create', () => {
   it('empty path', () => {
     const reducer = factory.create(createReducer, '$')
     expect(reducer.type).toBe('ReducerPath')
-    expect(reducer.name).toBe('.')
+    expect(reducer.name).toBe('$')
     expect(reducer.asCollection).toBe(false)
   })
 
@@ -109,7 +109,7 @@ describe('ReducerPath#body', () => {
     const acc = {
       value: 'test'
     }
-    const result = factory.create(createReducer, '$.').body(acc)
+    const result = factory.create(createReducer, '$').body(acc)
     expect(result).toBe('test')
   })
 

--- a/packages/data-point/lib/reducer-types/reducer-path/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-path/resolve.test.js
@@ -30,7 +30,7 @@ describe('ReducerPath#resolve', () => {
     const expected = {
       a: 1
     }
-    return resolve(expected, '$.').then(res => expect(res.value).toBe(expected))
+    return resolve(expected, '$').then(res => expect(res.value).toBe(expected))
   })
 
   test('resolve to context scope', () => {

--- a/packages/data-point/test/definitions/hash.js
+++ b/packages/data-point/test/definitions/hash.js
@@ -10,7 +10,7 @@ module.exports = {
     value: '$a.b.c'
   },
   'hash:asIs': {
-    value: '$.'
+    value: '$'
   },
   'hash:a.1': {
     value: '$a.h'

--- a/packages/data-point/test/definitions/integrations.js
+++ b/packages/data-point/test/definitions/integrations.js
@@ -5,7 +5,7 @@ module.exports = {
     value: '$a.f | hash:branchLeaf'
   },
   'hash:branchLeaf': {
-    value: '$.',
+    value: '$',
     mapKeys: {
       label: '$text',
       // using Collection map []


### PR DESCRIPTION
**What**: #52

<!-- Why are these changes necessary? -->
**Why**: `$` can be used instead of `$.`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->