### PR TITLE
feat(data-point/core): Support both addEntityType and addEntityTypes

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -2959,15 +2959,32 @@ dataPoint.addValue(objectPath, value)
 
 ## <a name="custom-entity-types">Custom Entity Types</a>
 
-DataPoint exposes a set of methods to help you build your own Custom Entity Types. With them you are enabled to build on top of the [base entity API](#entity-base-api). 
+DataPoint exposes a set of methods to help you build your own Custom Entity types. With them you are enabled to build on top of the [base entity API](#entity-base-api).
 
-### <a name="adding-entity-types">Adding new Entity Types</a>
+### <a name="adding-entity-types">Adding new Entity types</a>
 
-You may add new Entity Types through the [DataPoint.create](#api-data-point-create) method, or through the [dataPoint.addEntityTypes](#data-point-add-entity-types)
+You can add custom Entity types when creating a DataPoint instance with [DataPoint.create](#api-data-point-create); you can also add them later with [dataPoint.addEntityType](#data-point-add-entity-type) and/or [dataPoint.addEntityTypes](#data-point-add-entity-types).
+
+#### <a name="data-point-add-entity-types">dataPoint.addEntityType</a>
+
+Add a new Entity type to the DataPoint instance.
+
+**SYNOPSIS**
+
+```js
+dataPoint.addEntityType(id:String, spec:Object)
+```
+
+**ARGUMENTS**
+
+| Argument | Type | Description |
+|:---|:---|:---|
+| *id* | `String` | The name of the new Entity type. |
+| *spec* | `Object` | The Entity spec. |
 
 #### <a name="data-point-add-entity-types">dataPoint.addEntityTypes</a>
 
-Adds a new set of Entity Types to the DataPoint instance.
+Adds a new set of Entity types to the DataPoint instance.
 
 **SYNOPSIS**
 
@@ -2975,13 +2992,11 @@ Adds a new set of Entity Types to the DataPoint instance.
 dataPoint.addEntityTypes(specs:Object)
 ```
 
-This method will return a **Promise** if `done` is omitted.
-
 **ARGUMENTS**
 
 | Argument | Type | Description |
 |:---|:---|:---|
-| *specs* | `Object` | Key/value hash where each key is the name of the new Entity Type and value is the Entity spec API. |
+| *specs* | `Object` | Key/value hash where each key is the name of the new Entity type and value is the Entity spec. |
 
 Every Entity must expose two methods:
 

--- a/packages/data-point/lib/core/factory.js
+++ b/packages/data-point/lib/core/factory.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash')
 
 const normalizeEntities = require('./normalize-entities')
@@ -17,9 +16,14 @@ const EntityRequest = require('../entity-types/entity-request')
 const EntityControl = require('../entity-types/entity-control')
 const EntitySchema = require('../entity-types/entity-schema')
 
-function addToStore (store, reducers) {
-  _.forOwn(reducers, (value, key) => {
-    store.add(key, value, true)
+/**
+ * @param {Object} store
+ * @param {Object} items
+ * @param {boolean} override
+ */
+function addToStore (store, items, override) {
+  _.forOwn(items, (value, key) => {
+    store.add(key, value, override)
   })
 }
 
@@ -58,7 +62,8 @@ function create (spec) {
 
   // add single item (singular)
   manager.addValue = manager.values.add
-  manager.addEntityTypes = manager.entityTypes.add
+  manager.addEntityType = manager.entityTypes.add
+  manager.addEntityTypes = _.partial(addToStore, manager.entityTypes)
   manager.use = manager.middleware.use
 
   // add collection of items (plural)
@@ -67,20 +72,22 @@ function create (spec) {
   // using options to initialize dataPoint
 
   // built-in entity types
-  manager.addEntityTypes('transform', EntityTransform)
-  manager.addEntityTypes('entry', EntityEntry)
+  manager.addEntityType('transform', EntityTransform)
+  manager.addEntityType('entry', EntityEntry)
   // alias to entry, may be used to process any object type
-  manager.addEntityTypes('model', EntityEntry)
-  manager.addEntityTypes('hash', EntityHash)
-  manager.addEntityTypes('collection', EntityCollection)
-  manager.addEntityTypes('request', EntityRequest)
+  manager.addEntityType('model', EntityEntry)
+  manager.addEntityType('hash', EntityHash)
+  manager.addEntityType('collection', EntityCollection)
+  manager.addEntityType('request', EntityRequest)
   // for backwards compatibility
-  manager.addEntityTypes('source', EntityRequest)
-  manager.addEntityTypes('control', EntityControl)
-  manager.addEntityTypes('schema', EntitySchema)
+  manager.addEntityType('source', EntityRequest)
+  manager.addEntityType('control', EntityControl)
+  manager.addEntityType('schema', EntitySchema)
 
-  addToStore(manager.values, options.values)
-  addToStore(manager.entityTypes, options.entityTypes)
+  manager.addEntityTypes(options.entityTypes, true)
+
+  addToStore(manager.values, options.values, true)
+
   manager.addEntities(options.entities)
 
   return manager

--- a/packages/data-point/lib/stores/object-store-manager.js
+++ b/packages/data-point/lib/stores/object-store-manager.js
@@ -1,8 +1,8 @@
-
 const _ = require('lodash')
 
 /**
  * get the store
+ * @param {Object} manager
  * @return {Object}
  */
 function getStore (manager) {
@@ -13,6 +13,7 @@ module.exports.getStore = getStore
 
 /**
  * clears the store
+ * @param {Object}
  * @return {Object}
  */
 function clear (manager) {
@@ -24,8 +25,10 @@ module.exports.clear = clear
 
 /**
  * get value by path
- * @throws Will throw error if id is invalid
- * @param  {string} path - dot notation to access a filter path
+ * @throws if the value for path is undefined
+ * @param {Object} manager
+ * @param {Function} errorInfoCb
+ * @param {string} path - dot notation to access an object value
  * @return {*}
  */
 function get (manager, errorInfoCb, path) {
@@ -43,21 +46,24 @@ function get (manager, errorInfoCb, path) {
 module.exports.get = get
 
 /**
- * get filter by path
- * @throws Will throw error if id already exists and override is not true
- * @param  {string} id - filter id
+ * @throws if a value already exists for path and override is not true
+ * @param {Object} manager
+ * @param {Function} errorInfoCb
+ * @param {string} path - dot notation to set an object value
+ * @param {*} value
+ * @param {boolean} override
  * @return {*} returns reference to entire manager.store
  */
-function add (manager, errorInfoCb, id, value, override) {
-  const filter = _.get(manager.store, id)
+function add (manager, errorInfoCb, path, value, override) {
+  const filter = _.get(manager.store, path)
   if (!override && filter) {
-    const errorInfo = errorInfoCb(id)
+    const errorInfo = errorInfoCb(path)
     const e = new Error(errorInfo.message)
     e.name = errorInfo.message.name
     throw e
   }
 
-  _.set(manager.store, id, value)
+  _.set(manager.store, path, value)
 
   return manager.store
 }
@@ -66,6 +72,7 @@ module.exports.add = add
 
 /**
  * create instance
+ * @param {Object} spec
  * @return {Object}
  */
 function create (spec) {

--- a/packages/data-point/lib/stores/store-manager.js
+++ b/packages/data-point/lib/stores/store-manager.js
@@ -1,8 +1,8 @@
-
 const _ = require('lodash')
 
 /**
  * get all added models
+ * @param {Object} manager
  * @return {Map}
  */
 function getStore (manager) {
@@ -13,6 +13,7 @@ module.exports.getStore = getStore
 
 /**
  * clear map
+ * @param {Object} manager
  * @return {Map}
  */
 function clear (manager) {
@@ -23,9 +24,11 @@ function clear (manager) {
 module.exports.clear = clear
 
 /**
- * get value by path
- * @throws Will throw error if id is invalid
- * @param  {string} id - model id
+ * get value by id
+ * @throws if value for id is undefined
+ * @param {Object} manager
+ * @param {Function} errorInfoCb
+ * @param {string} id - model id
  * @return {*}
  */
 function get (manager, errorInfoCb, id) {
@@ -43,13 +46,17 @@ function get (manager, errorInfoCb, id) {
 module.exports.get = get
 
 /**
- * get filter by path
- * @throws Will throw error if id already exists and override is not true
- * @param  {string} id - filter id
- * @return {*} returns reference to entire store
+ * @throws if value already exists for id and override is not true
+ * @param {Object} manager
+ * @param {Function} errorInfoCb
+ * @param {Function} factory
+ * @param {string} id
+ * @param {Object} spec
+ * @param {boolean} override
+ * @return {Map} returns reference to entire store
  */
-function add (manager, errorInfoCb, factory, id, spec) {
-  if (manager.store.get(id)) {
+function add (manager, errorInfoCb, factory, id, spec, override) {
+  if (manager.store.get(id) && !override) {
     const errorInfo = errorInfoCb(id)
     const e = new Error(errorInfo.message)
     e.name = errorInfo.name
@@ -75,6 +82,10 @@ function add (manager, errorInfoCb, factory, id, spec) {
 
 module.exports.add = add
 
+/**
+ * @param {Object} spec
+ * @returns {Object}
+ */
 function create (spec) {
   const manager = {
     store: new Map()

--- a/packages/data-point/lib/stores/values.js
+++ b/packages/data-point/lib/stores/values.js
@@ -1,4 +1,3 @@
-
 const ObjectStoreManager = require('./object-store-manager')
 
 /**


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Closes #56

<!-- Why are these changes necessary? -->
**Why**: `dataPoint.addEntityTypes` was expecting the wrong parameters

<!-- How were these changes implemented? -->
**How**: DataPoint instances now have both an `addEntityType` and an `addEntityTypes` method

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
