### PR TITLE
fix(data-point/entity-request): Remove support for EntityRequest#value

### DIFF
--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -134,9 +134,7 @@ function resolveRequest (acc, resolveReducer) {
 module.exports.resolveRequest = resolveRequest
 
 function resolve (acc, resolveReducer) {
-  const entity = acc.reducer.spec
   return Promise.resolve(acc)
-    .then(itemContext => resolveReducer(itemContext, entity.value))
     .then(itemContext => resolveOptions(itemContext, resolveReducer))
     .then(itemContext => resolveUrl(itemContext))
     .then(itemContext => resolveBeforeRequest(itemContext, resolveReducer))


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Remove support for the `EntityRequest#value` property

<!-- Why are these changes necessary? -->
**Why**: closes #154

<!-- How were these changes implemented? -->
**How**: Delete the line `.then(itemContext => resolveReducer(itemContext, entity.value))` from `EntityRequest#resolve`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation n/a
- [ ] Tests n/a
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->