### PR TITLE
refactor(data-point/reducer-object): Replace a Promise.reduce with Array.reduce

### DIFF
--- a/packages/data-point/lib/reducer-types/reducer-object/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-object/resolve.js
@@ -14,16 +14,18 @@ function resolve (manager, resolveReducer, accumulator, reducer) {
     return Promise.resolve(accumulator)
   }
 
-  const props = Promise.map(reducer.props, ({ path, reducer }) => {
+  return Promise.map(reducer.props, ({ path, reducer }) => {
     return resolveReducer(manager, accumulator, reducer).then(({ value }) => ({
       path,
       value
     }))
+  }).then(result => {
+    const value = result.reduce(
+      (acc, { path, value }) => set(acc, path, value),
+      {}
+    )
+    return utils.set(accumulator, 'value', value)
   })
-
-  return props
-    .reduce((acc, { path, value }) => set(acc, path, value), {})
-    .then(value => utils.set(accumulator, 'value', value))
 }
 
 module.exports.resolve = resolve


### PR DESCRIPTION
**What**: Use `Array.reduce` inside of `ReducerObject#resolve` (closes #164)

<!-- Why are these changes necessary? -->
**Why**: Should improve performance.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation n/a
- [ ] Tests n/a
- [x] Ready to be merged