### PR TITLE
Omit options.auth from acc and error objects

### DIFF
--- a/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
@@ -6,7 +6,8 @@ exports[`resolveRequest log errors when request fails 1`] = `
 Entity info:
   - Id: test:test
   - options: { json: true,
-  url: 'http://remote.test/source1' }
+  url: 'http://remote.test/source1',
+  auth: '[omitted]' }
   - value: 'foo'
 
   Request:
@@ -19,6 +20,7 @@ Entity info:
   transform: undefined,
   simple: true,
   resolveWithFullResponse: false,
-  transform2xxOnly: false }
+  transform2xxOnly: false,
+  auth: '[omitted]' }
 "
 `;

--- a/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolve it should omit options.auth when encountering an error 1`] = `
+"404 - undefined
+
+Entity info:
+  - Id: request:a9
+  - options: { auth: '[omitted]',
+  method: 'GET',
+  json: true,
+  url: 'http://remote.test/source1' }
+  - value: {}
+
+  Request:
+  - message: '404 - undefined'
+  - statusCode: 404
+  - options: { auth: '[omitted]',
+  method: 'GET',
+  json: true,
+  url: 'http://remote.test/source1',
+  callback: [Function: RP$callback],
+  transform: undefined,
+  simple: true,
+  resolveWithFullResponse: false,
+  transform2xxOnly: false }
+"
+`;
+
 exports[`resolveRequest log errors when request fails 1`] = `
 "404 - \\"not found\\"
 

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -105,18 +105,22 @@ function resolveRequest (acc, resolveReducer) {
     .then(result => utils.set(acc, 'value', result))
     .catch(error => {
       // remove auth objects from acc and error
-      _.set(acc, 'options.auth', '[omitted]')
-      _.set(error, 'options.auth', '[omitted]')
+      const redactedAcc = _.set(acc, 'options.auth', '[omitted]')
+      const redactedError = _.set(error, 'options.auth', '[omitted]')
 
       const message = [
         'Entity info:',
         '\n  - Id: ',
-        _.get(acc, 'reducer.spec.id'),
+        _.get(redactedAcc, 'reducer.spec.id'),
         '\n',
-        utils.inspectProperties(acc, ['options', 'params', 'value'], '  '),
+        utils.inspectProperties(
+          redactedAcc,
+          ['options', 'params', 'value'],
+          '  '
+        ),
         '\n  Request:\n',
         utils.inspectProperties(
-          error,
+          redactedError,
           ['error', 'message', 'statusCode', 'options', 'body'],
           '  '
         )
@@ -124,7 +128,7 @@ function resolveRequest (acc, resolveReducer) {
 
       // this is useful in the case the error itself is not logged by the
       // implementation
-      console.info(error.toString(), message)
+      console.info(redactedError.toString(), message)
 
       // attaching to error so it can be exposed by a handler outside datapoint
       error.message = `${error.message}\n\n${message}`

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -106,8 +106,8 @@ function resolveRequest (acc, resolveReducer) {
     .then(result => utils.set(acc, 'value', result))
     .catch(error => {
       // remove auth objects from acc and error for printing to console
-      const redactedAcc = fp.set('options.auth')('[omitted]')(acc)
-      const redactedError = fp.set('options.auth')('[omitted]')(error)
+      const redactedAcc = fp.set('options.auth', '[omitted]', acc)
+      const redactedError = fp.set('options.auth', '[omitted]', error)
 
       const message = [
         'Entity info:',

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const fp = require('lodash/fp')
 const Promise = require('bluebird')
 const rp = require('request-promise')
 
@@ -104,9 +105,9 @@ function resolveRequest (acc, resolveReducer) {
   return rp(acc.options)
     .then(result => utils.set(acc, 'value', result))
     .catch(error => {
-      // remove auth objects from acc and error
-      const redactedAcc = _.set(acc, 'options.auth', '[omitted]')
-      const redactedError = _.set(error, 'options.auth', '[omitted]')
+      // remove auth objects from acc and error for printing to console
+      const redactedAcc = fp.set('options.auth')('[omitted]')(acc)
+      const redactedError = fp.set('options.auth')('[omitted]')(error)
 
       const message = [
         'Entity info:',

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -104,6 +104,10 @@ function resolveRequest (acc, resolveReducer) {
   return rp(acc.options)
     .then(result => utils.set(acc, 'value', result))
     .catch(error => {
+      // remove auth objects from acc and error
+      _.set(acc, 'options.auth', '[omitted]')
+      _.set(error, 'options.auth', '[omitted]')
+
       const message = [
         'Entity info:',
         '\n  - Id: ',

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -391,4 +391,15 @@ describe('resolve', () => {
       })
     })
   })
+
+  test('it should omit options.auth when encountering an error', () => {
+    nock('http://remote.test')
+      .get('/source1')
+      .reply(404)
+
+    return transform('request:a9', {}).catch(err => {
+      expect(err.statusCode).toEqual(404)
+      expect(err.options.auth).toEqual('[omitted]')
+    })
+  })
 })

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -399,7 +399,13 @@ describe('resolve', () => {
 
     return transform('request:a9', {}).catch(err => {
       expect(err.statusCode).toEqual(404)
-      expect(err.options.auth).toEqual('[omitted]')
+      expect(err.message).toMatchSnapshot()
+
+      // credentials are still available in the raw error.options
+      expect(err.options.auth).toEqual({
+        user: 'cool_user',
+        pass: 'super_secret!'
+      })
     })
   })
 })

--- a/packages/data-point/test/definitions/requests.js
+++ b/packages/data-point/test/definitions/requests.js
@@ -86,5 +86,14 @@ module.exports = {
     options: {
       baseUrl: () => 'http://remote.test'
     }
+  },
+  'request:a9': {
+    url: 'http://remote.test/source1',
+    options: {
+      auth: {
+        user: () => 'cool_user',
+        pass: () => 'super_secret!'
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Remove `auth` object from `request.options` before returning the `acc` or `error`, or printing those values to the console.

<!-- Why are these changes necessary? -->
**Why**: The `options` object was being printed to the `console` with the authorization credentials. Depending on the implementation credentials could leak into stored logs and test snapshots without a user knowing. This removes authorization creds before returning the `acc`/`error`. ☠️ 

<!-- How were these changes implemented? -->
**How**: using [lodash/fp#set](https://github.com/lodash/lodash/wiki/FP-Guide)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation N/A
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
