### PR TITLE
feat(data-point/reducer-default: Add the ReducerDefault type

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -37,6 +37,7 @@ npm install --save data-point
   - [filter](#reducer-filter)
   - [find](#reducer-find)
   - [constant](#reducer-constant)
+  - [withDefault](#reducer-default)
 - [Entities](#entities)
   - [dataPoint.addEntities](#api-data-point-add-entities)
   - [Built-in entities](#built-in-entities)
@@ -1187,6 +1188,37 @@ constant(value:*):*
     })
   ```
 </details>
+
+### <a name="reducer-default">withDefault</a>
+
+The **withDefault** reducer adds a default value to any reducer type. If the reducer resolves to `null`, `undefined`, `NaN`, or an empty string, the default is returned instead.
+
+**SYNOPSIS**
+
+```js
+withDefault(source:*, value:*):*
+```
+
+**Reducer's arguments**
+
+| Argument | Type | Description |
+|:---|:---|:---|
+| *source* | * | Source data for creating a [reducer](#reducers)  |
+| *value* | * | The default value to use |
+
+**EXAMPLE:**
+
+```js
+const { withDefault } = DataPoint.helpers
+
+const input = {
+  a: undefined
+}
+
+const r = withDefault('$a', 50)
+
+dataPoint.resolve(r, input) // => 50
+```
 
 ## <a name="entities">Entities</a>
 

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -1191,7 +1191,8 @@ constant(value:*):*
 
 ### <a name="reducer-default">withDefault</a>
 
-The **withDefault** reducer adds a default value to any reducer type. If the reducer resolves to `null`, `undefined`, `NaN`, or an empty string, the default is returned instead.
+The **withDefault** reducer adds a default value to any reducer type. If the reducer resolves to `null`, `undefined`, `NaN`, or `''`,
+the default is returned instead.
 
 **SYNOPSIS**
 
@@ -1204,7 +1205,9 @@ withDefault(source:*, value:*):*
 | Argument | Type | Description |
 |:---|:---|:---|
 | *source* | * | Source data for creating a [reducer](#reducers)  |
-| *value* | * | The default value to use |
+| *value* | * | The default value to use (or a function that returns the default value) |
+
+The default value is not cloned before it's returned, so it's good practice to wrap any Objects in a function.
 
 **EXAMPLE:**
 
@@ -1215,9 +1218,19 @@ const input = {
   a: undefined
 }
 
-const r = withDefault('$a', 50) // adds a default to a PathReducer
+// adds a default to a PathReducer
+const r1 = withDefault('$a', 50)
 
-dataPoint.resolve(r, input) // => 50
+dataPoint.resolve(r1, input) // => 50
+
+// passing a function is useful when the default value is
+// an object, because it returns a new object every time
+const r2 = withDefault('$a', () => {
+  return { b: 1 }
+})
+
+dataPoint.resolve(r2, input) // => { b: 1 }
+
 ```
 
 ## <a name="entities">Entities</a>

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -1215,7 +1215,7 @@ const input = {
   a: undefined
 }
 
-const r = withDefault('$a', 50)
+const r = withDefault('$a', 50) // adds a default to a PathReducer
 
 dataPoint.resolve(r, input) // => 50
 ```

--- a/packages/data-point/lib/__snapshots__/index.test.js.snap
+++ b/packages/data-point/lib/__snapshots__/index.test.js.snap
@@ -20,6 +20,7 @@ Object {
     "map": [Function],
     "omit": [Function],
     "pick": [Function],
+    "withDefault": [Function],
   },
   "reducify": [Function],
   "reducifyAll": [Function],

--- a/packages/data-point/lib/helpers/__snapshots__/helpers.test.js.snap
+++ b/packages/data-point/lib/helpers/__snapshots__/helpers.test.js.snap
@@ -21,6 +21,7 @@ Object {
     "map": [Function],
     "omit": [Function],
     "pick": [Function],
+    "withDefault": [Function],
   },
   "isReducer": [Function],
   "mockReducer": [Function],

--- a/packages/data-point/lib/helpers/helpers.js
+++ b/packages/data-point/lib/helpers/helpers.js
@@ -14,6 +14,7 @@ module.exports.helpers = {
   map: stubFactories.map,
   omit: stubFactories.omit,
   pick: stubFactories.pick,
+  withDefault: stubFactories.withDefault,
   isString: typeCheckFunctionReducers.isString,
   isNumber: typeCheckFunctionReducers.isNumber,
   isBoolean: typeCheckFunctionReducers.isBoolean,

--- a/packages/data-point/lib/reducer-types/factory.js
+++ b/packages/data-point/lib/reducer-types/factory.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const util = require('util')
 
-const REDUCER_SYMBOL = require('./reducer-symbol')
+const { IS_REDUCER, DEFAULT_VALUE } = require('./reducer-symbols')
 
 const ReducerEntity = require('./reducer-entity')
 const ReducerFunction = require('./reducer-function')
@@ -24,7 +24,7 @@ const reducerTypes = [
  * @returns {boolean}
  */
 function isReducer (item) {
-  return !!(item && item[REDUCER_SYMBOL])
+  return !!(item && item[IS_REDUCER])
 }
 
 module.exports.isReducer = isReducer
@@ -34,7 +34,7 @@ module.exports.isReducer = isReducer
  * @param {*} source
  * @returns {Array<reducer>|reducer}
  */
-function dealWithPipeOperators (source) {
+function normalizeInput (source) {
   let result = ReducerList.parse(source)
   if (result.length === 1) {
     // do not create a ReducerList that only contains a single reducer
@@ -47,11 +47,12 @@ function dealWithPipeOperators (source) {
 /**
  * parse reducer
  * @param {*} source
+ * @param {Object} options
  * @throws if source is not a valid type for creating a reducer
  * @return {reducer}
  */
-function createReducer (source) {
-  source = dealWithPipeOperators(source)
+function createReducer (source, options = {}) {
+  source = normalizeInput(source)
   const reducerType = reducerTypes.find(r => r.isType(source))
 
   if (_.isUndefined(reducerType)) {
@@ -68,7 +69,11 @@ function createReducer (source) {
 
   // NOTE: recursive call
   const reducer = reducerType.create(createReducer, source)
-  reducer[REDUCER_SYMBOL] = true
+  reducer[IS_REDUCER] = true
+  if (_.has(options, 'default')) {
+    reducer[DEFAULT_VALUE] = { value: options.default }
+  }
+
   return Object.freeze(reducer)
 }
 

--- a/packages/data-point/lib/reducer-types/reducer-helpers/index.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/index.js
@@ -2,6 +2,7 @@ const createStub = require('./reducer-stub').create
 
 const reducerAssign = require('./reducer-assign')
 const reducerConstant = require('./reducer-constant')
+const reducerDefault = require('./reducer-default')
 const reducerFilter = require('./reducer-filter')
 const reducerFind = require('./reducer-find')
 const reducerMap = require('./reducer-map')
@@ -32,6 +33,7 @@ module.exports.isType = require('./reducer-stub').isType
 const reducers = {
   [reducerAssign.type]: reducerAssign,
   [reducerConstant.type]: reducerConstant,
+  [reducerDefault.type]: reducerDefault,
   [reducerFilter.type]: reducerFilter,
   [reducerFind.type]: reducerFind,
   [reducerMap.type]: reducerMap,
@@ -48,6 +50,7 @@ function bindStubFunction (reducerType) {
 const stubFactories = {
   [reducerAssign.name]: bindStubFunction(reducerAssign.type),
   [reducerConstant.name]: bindStubFunction(reducerConstant.type),
+  [reducerDefault.name]: bindStubFunction(reducerDefault.type),
   [reducerFilter.name]: bindStubFunction(reducerFilter.type),
   [reducerFind.name]: bindStubFunction(reducerFind.type),
   [reducerMap.name]: bindStubFunction(reducerMap.type),

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/factory.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/factory.js
@@ -1,0 +1,22 @@
+const REDUCER_DEFAULT = 'ReducerDefault'
+
+module.exports.type = REDUCER_DEFAULT
+
+const HELPER_NAME = 'withDefault'
+
+module.exports.name = HELPER_NAME
+
+/**
+ * this is used as a decorator
+ * it attaches a default value
+ * to an existing reducer type
+ * @param {Function} createReducer
+ * @param {*} source - raw source for a reducer
+ * @param {*} value
+ * @return {reducer}
+ */
+function create (createReducer, source, value) {
+  return createReducer(source, { default: value })
+}
+
+module.exports.create = create

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/factory.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/factory.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+
+const Factory = require('./factory')
+const createReducer = require('../../index').create
+const { IS_REDUCER, DEFAULT_VALUE } = require('../../reducer-symbols')
+
+describe('ReducerDefault#factory', () => {
+  test('create with ReducerPath and string as default', () => {
+    const reducer = Factory.create(createReducer, '$a', 'DEFAULT_VALUE')
+    expect(reducer[IS_REDUCER]).toBe(true)
+    expect(reducer[DEFAULT_VALUE]).toEqual({ value: 'DEFAULT_VALUE' })
+    expect(reducer.type).toBe('ReducerPath')
+  })
+  test('create with ReducerPath and function as default', () => {
+    const _default = () => 'DEFAULT_VALUE'
+    const reducer = Factory.create(createReducer, '$a', _default)
+    expect(reducer[IS_REDUCER]).toBe(true)
+    expect(reducer[DEFAULT_VALUE]).toEqual({ value: _default })
+    expect(reducer.type).toBe('ReducerPath')
+  })
+})

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/index.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/index.js
@@ -1,0 +1,9 @@
+const factory = require('./factory')
+const resolve = require('./resolve').resolve
+
+module.exports = {
+  create: factory.create,
+  type: factory.type,
+  name: factory.name,
+  resolve: resolve
+}

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
@@ -1,6 +1,17 @@
-const isNil = require('lodash/isNil')
-
 const utils = require('../../../utils')
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+function isFalsy (value) {
+  return (
+    value === null ||
+    typeof value === 'undefined' ||
+    Number.isNaN(value) ||
+    value === ''
+  )
+}
 
 /**
  * @param {Accumulator} accumulator
@@ -9,7 +20,7 @@ const utils = require('../../../utils')
  */
 function resolve (accumulator, _default) {
   let value = accumulator.value
-  if (Number.isNaN(value) || isNil(value) || value === '') {
+  if (isFalsy(value)) {
     value = typeof _default === 'function' ? _default() : _default
   }
 

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
@@ -5,7 +5,7 @@ const utils = require('../../../utils')
 /**
  * @param {Accumulator} accumulator
  * @param {*} _default
- * @returns {Promise<Accumulator>}
+ * @returns {Accumulator}
  */
 function resolve (accumulator, _default) {
   let value = accumulator.value

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
@@ -1,0 +1,19 @@
+const isNil = require('lodash/isNil')
+
+const utils = require('../../../utils')
+
+/**
+ * @param {Accumulator} accumulator
+ * @param {*} _default
+ * @returns {Promise<Accumulator>}
+ */
+function resolve (accumulator, _default) {
+  let value = accumulator.value
+  if (Number.isNaN(value) || isNil(value) || value === '') {
+    value = typeof _default === 'function' ? _default() : _default
+  }
+
+  return utils.assign(accumulator, { value })
+}
+
+module.exports.resolve = resolve

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+
+const { resolve } = require('./resolve')
+
+describe('ReducerDefault#resolve', () => {
+  test('resolve with input value', () => {
+    expect(resolve({ value: 0 }, 5)).toEqual({ value: 0 })
+    expect(resolve({ value: false }, 5)).toEqual({ value: false })
+    expect(resolve({ value: 'value' }, 5)).toEqual({ value: 'value' })
+    expect(resolve({ value: { a: 1 } }, 5)).toEqual({ value: { a: 1 } })
+  })
+  test('resolve with default value', () => {
+    expect(resolve({ value: '' }, 5)).toEqual({ value: 5 })
+    expect(resolve({ value: undefined }, 5)).toEqual({ value: 5 })
+    expect(resolve({ value: null }, 5)).toEqual({ value: 5 })
+    expect(resolve({ value: NaN }, 5)).toEqual({ value: 5 })
+    expect(resolve({ value: undefined }, undefined)).toEqual({
+      value: undefined
+    })
+  })
+  test('resolve with default value function', () => {
+    expect(resolve({ value: undefined }, () => 5)).toEqual({ value: 5 })
+  })
+})
+
+// TODO point out that it does not clone the object

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.test.js
@@ -22,5 +22,3 @@ describe('ReducerDefault#resolve', () => {
     expect(resolve({ value: undefined }, () => 5)).toEqual({ value: 5 })
   })
 })
-
-// TODO point out that it does not clone the object

--- a/packages/data-point/lib/reducer-types/reducer-symbol.js
+++ b/packages/data-point/lib/reducer-types/reducer-symbol.js
@@ -1,1 +1,0 @@
-module.exports = Symbol('reducer')

--- a/packages/data-point/lib/reducer-types/reducer-symbols.js
+++ b/packages/data-point/lib/reducer-types/reducer-symbols.js
@@ -1,0 +1,3 @@
+module.exports.IS_REDUCER = Symbol('reducer')
+
+module.exports.DEFAULT_VALUE = Symbol('default')

--- a/packages/data-point/lib/reducer-types/resolve.js
+++ b/packages/data-point/lib/reducer-types/resolve.js
@@ -55,16 +55,16 @@ function resolveReducer (manager, accumulator, reducer) {
     return Promise.resolve(accumulator)
   }
 
-  let resolve = getResolveFunction(reducer)
+  const resolve = getResolveFunction(reducer)
   // NOTE: recursive call
-  resolve = resolve(manager, resolveReducer, accumulator, reducer)
+  const result = resolve(manager, resolveReducer, accumulator, reducer)
   if (hasDefault(reducer)) {
     const _default = reducer[DEFAULT_VALUE].value
     const resolveDefault = reducers.ReducerDefault.resolve
-    return resolve.then(acc => resolveDefault(acc, _default))
+    return result.then(acc => resolveDefault(acc, _default))
   }
 
-  return resolve
+  return result
 }
 
 module.exports.resolve = resolveReducer

--- a/packages/data-point/lib/reducer-types/resolve.js
+++ b/packages/data-point/lib/reducer-types/resolve.js
@@ -1,11 +1,12 @@
 const Promise = require('bluebird')
+
 const ReducerEntity = require('./reducer-entity')
 const ReducerFunction = require('./reducer-function')
 const ReducerList = require('./reducer-list')
 const ReducerObject = require('./reducer-object')
 const ReducerPath = require('./reducer-path')
-
 const ReducerHelpers = require('./reducer-helpers').reducers
+const { DEFAULT_VALUE } = require('./reducer-symbols')
 
 const reducers = Object.assign({}, ReducerHelpers, {
   [ReducerEntity.type]: ReducerEntity,
@@ -16,13 +17,36 @@ const reducers = Object.assign({}, ReducerHelpers, {
 })
 
 /**
+ * @param {Reducer} reducer
+ * @return {boolean}
+ */
+function hasDefault (reducer) {
+  return !!reducer[DEFAULT_VALUE]
+}
+
+module.exports.hasDefault = hasDefault
+
+/**
+ * @param {Reducer} reducer
+ * @return {Function}
+ */
+function getResolveFunction (reducer) {
+  const reducerType = reducers[reducer.type]
+  if (reducerType) {
+    return reducerType.resolve
+  }
+
+  throw new Error(`Reducer type '${reducer.type}' was not recognized`)
+}
+
+/**
  * apply a Reducer to an accumulator
  * @param {Object} manager
  * @param {Accumulator} accumulator
  * @param {Reducer} reducer
  * @returns {Promise<Accumulator>}
  */
-function resolve (manager, accumulator, reducer) {
+function resolveReducer (manager, accumulator, reducer) {
   // this conditional is here because BaseEntity#resolve
   // does not check that lifecycle methods are defined
   // before trying to resolve them
@@ -30,13 +54,16 @@ function resolve (manager, accumulator, reducer) {
     return Promise.resolve(accumulator)
   }
 
-  const reducerType = reducers[reducer.type]
-  if (!reducerType) {
-    throw new Error(`Reducer type '${reducer.type}' was not recognized`)
+  let resolve = getResolveFunction(reducer)
+  // NOTE: recursive call
+  resolve = resolve(manager, resolveReducer, accumulator, reducer)
+  if (hasDefault(reducer)) {
+    const _default = reducer[DEFAULT_VALUE].value
+    const afterResolve = reducers.ReducerDefault.resolve
+    return resolve.then(acc => afterResolve(acc, _default))
   }
 
-  // NOTE: recursive call
-  return reducerType.resolve(manager, resolve, accumulator, reducer)
+  return resolve
 }
 
-module.exports.resolve = resolve
+module.exports.resolve = resolveReducer

--- a/packages/data-point/lib/reducer-types/resolve.js
+++ b/packages/data-point/lib/reducer-types/resolve.js
@@ -28,6 +28,7 @@ module.exports.hasDefault = hasDefault
 
 /**
  * @param {Reducer} reducer
+ * @throws if reducer is not valid
  * @return {Function}
  */
 function getResolveFunction (reducer) {

--- a/packages/data-point/lib/reducer-types/resolve.js
+++ b/packages/data-point/lib/reducer-types/resolve.js
@@ -60,8 +60,8 @@ function resolveReducer (manager, accumulator, reducer) {
   resolve = resolve(manager, resolveReducer, accumulator, reducer)
   if (hasDefault(reducer)) {
     const _default = reducer[DEFAULT_VALUE].value
-    const afterResolve = reducers.ReducerDefault.resolve
-    return resolve.then(acc => afterResolve(acc, _default))
+    const resolveDefault = reducers.ReducerDefault.resolve
+    return resolve.then(acc => resolveDefault(acc, _default))
   }
 
   return resolve


### PR DESCRIPTION
**What**: Adds the `ReducerDefault` type (closes #169)

**Why**: This will add default values to any reducer.

**How**: Instead of actually creating a new reducer type, this just adds a `default` property to any existing reducer. The property uses a symbol to avoid any future conflicts.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [x] Documentation
- [x] Tests
- [x] Ready to be merged