### PR TITLE
Change execution order to have type checks as bookends

### DIFF
--- a/packages/data-point/examples/entity-model-error-handled.js
+++ b/packages/data-point/examples/entity-model-error-handled.js
@@ -4,7 +4,12 @@ const dataPoint = require('../').create()
 dataPoint.addEntities({
   'model:getArray': {
     // points to a NON Array value
-    value: '$a.b',
+    value: [
+      '$a.b',
+      () => {
+        throw new Error('error from value reducer')
+      }
+    ],
     outputType: 'array',
     error: input => {
       // prints out the error

--- a/packages/data-point/examples/entity-model-error-handled.js
+++ b/packages/data-point/examples/entity-model-error-handled.js
@@ -4,12 +4,7 @@ const dataPoint = require('../').create()
 dataPoint.addEntities({
   'model:getArray': {
     // points to a NON Array value
-    value: [
-      '$a.b',
-      () => {
-        throw new Error('error from value reducer')
-      }
-    ],
+    value: '$a.b',
     outputType: 'array',
     error: input => {
       // prints out the error

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -7,3 +7,5 @@ exports[`ResolveEntity.resolveEntity inputType - throws error if inputType does 
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -5,3 +5,5 @@ exports[`ResolveEntity.resolveEntity if custom typeCheck throws then fail 1`] = 
 exports[`ResolveEntity.resolveEntity inputType - throws error if inputType does not pass 1`] = `[Error: value did not pass type check, type expected: number but recevied: string. The value received is: 'foo']`;
 
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`ResolveEntity.resolveEntity inputType - throws error if inputType does not pass 1`] = `[Error: value did not pass type check, type expected: number but recevied: string. The value received is: 'foo']`;
 
+exports[`ResolveEntity.resolveEntity outputType fails if error method catches typeCheck errors and returns bad value 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 2]`;
+
 exports[`ResolveEntity.resolveEntity outputType is bypassed if error throws error 1`] = `[Error: error from before method]`;
 
 exports[`ResolveEntity.resolveEntity outputType throws error if after method returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -8,4 +8,12 @@ exports[`ResolveEntity.resolveEntity outputType - throws error if outputType doe
 
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when before changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when global after middleware changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when global before middleware changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:before changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -17,3 +17,7 @@ exports[`ResolveEntity.resolveEntity outputType - throws error if outputType doe
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
 exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:before changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - typeCheck fails if error method returns value with incorrect type 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType - typeCheck is bypassed if error method throws error 1`] = `[Error: error from before method]`;

--- a/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/base-entity/__snapshots__/resolve.test.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResolveEntity.resolveEntity if custom typeCheck throws then fail 1`] = `[Error: custom type error]`;
-
 exports[`ResolveEntity.resolveEntity inputType - throws error if inputType does not pass 1`] = `[Error: value did not pass type check, type expected: number but recevied: string. The value received is: 'foo']`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType is bypassed if error throws error 1`] = `[Error: error from before method]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if after method returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when before changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if after middleware returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when global after middleware changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if before method returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when global before middleware changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if custom typeCheck fails 1`] = `[Error: custom type error]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:after changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if global after middleware returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - throws error if outputType does not pass when model:before changes output 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if global before middleware returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - typeCheck fails if error method returns value with incorrect type 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if middleware before returns value that does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
 
-exports[`ResolveEntity.resolveEntity outputType - typeCheck is bypassed if error method throws error 1`] = `[Error: error from before method]`;
+exports[`ResolveEntity.resolveEntity outputType throws error if value does not pass typeCheck 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;
+
+exports[`ResolveEntity.resolveEntity outputType throws if error method does not return value with correct type 1`] = `[Error: value did not pass type check, type expected: string but recevied: number. The value received is: 1]`;

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -156,6 +156,13 @@ function resolveEntity (
       if (error.bypass === true) {
         return error.bypassValue
       }
+
+      throw error
+    })
+    .then(acc =>
+      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
+    )
+    .catch(error => {
       // attach entity information to help debug
       error.entityId = currentAccumulator.reducer.spec.id
 
@@ -164,11 +171,10 @@ function resolveEntity (
         error,
         currentAccumulator,
         resolveReducer
+      ).then(acc =>
+        typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
       )
     })
-    .then(acc =>
-      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
-    )
     .then(resultContext => {
       if (trace === true) {
         console.timeEnd(timeId)

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -151,14 +151,18 @@ function resolveEntity (
     .then(acc => resolveReducer(manager, acc, acc.reducer.spec.after))
     .then(acc => resolveMiddleware(manager, `${reducer.entityType}:after`, acc))
     .then(acc => resolveMiddleware(manager, `after`, acc))
-    .then(acc =>
-      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
-    )
     .catch(error => {
       // checking if this is an error to bypass the `then` chain
       if (error.bypass === true) {
         return error.bypassValue
       }
+
+      throw error
+    })
+    .then(acc =>
+      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
+    )
+    .catch(error => {
       // attach entity information to help debug
       error.entityId = currentAccumulator.reducer.spec.id
 

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -156,13 +156,6 @@ function resolveEntity (
       if (error.bypass === true) {
         return error.bypassValue
       }
-
-      throw error
-    })
-    .then(acc =>
-      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
-    )
-    .catch(error => {
       // attach entity information to help debug
       error.entityId = currentAccumulator.reducer.spec.id
 
@@ -173,6 +166,9 @@ function resolveEntity (
         resolveReducer
       )
     })
+    .then(acc =>
+      typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
+    )
     .then(resultContext => {
       if (trace === true) {
         console.timeEnd(timeId)

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -139,21 +139,21 @@ function resolveEntity (
   const resolveReducerBound = _.partial(resolveReducer, manager)
 
   return Promise.resolve(accUid)
+    .then(acc =>
+      typeCheck(manager, acc, acc.reducer.spec.inputType, resolveReducer)
+    )
     .then(acc => resolveMiddleware(manager, `before`, acc))
     .then(acc =>
       resolveMiddleware(manager, `${reducer.entityType}:before`, acc)
     )
-    .then(acc =>
-      typeCheck(manager, acc, acc.reducer.spec.inputType, resolveReducer)
-    )
     .then(acc => resolveReducer(manager, acc, acc.reducer.spec.before))
     .then(acc => mainResolver(acc, resolveReducerBound))
     .then(acc => resolveReducer(manager, acc, acc.reducer.spec.after))
+    .then(acc => resolveMiddleware(manager, `${reducer.entityType}:after`, acc))
+    .then(acc => resolveMiddleware(manager, `after`, acc))
     .then(acc =>
       typeCheck(manager, acc, acc.reducer.spec.outputType, resolveReducer)
     )
-    .then(acc => resolveMiddleware(manager, `${reducer.entityType}:after`, acc))
-    .then(acc => resolveMiddleware(manager, `after`, acc))
     .catch(error => {
       // checking if this is an error to bypass the `then` chain
       if (error.bypass === true) {

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -211,8 +211,24 @@ describe('ResolveEntity.resolveEntity', () => {
       expect(ac.value).toEqual(1)
     })
   })
+})
 
-  test('outputType - throws error if outputType does not pass', () => {
+describe('ResolveEntity.resolveEntity outputType', () => {
+  const defaultResolver = (acc, resolveReducer) => Promise.resolve(acc)
+
+  const resolveEntity = (entityId, input, options, resolver) => {
+    const racc = helpers.createAccumulator.call(null, input, options)
+    const reducer = createReducerEntity(createReducer, entityId)
+    return ResolveEntity.resolveEntity(
+      dataPoint,
+      resolveReducer,
+      racc,
+      reducer,
+      resolver || defaultResolver
+    )
+  }
+
+  test('throws error if value does not pass typeCheck', () => {
     return resolveEntity('model:c.1', 1)
       .catch(e => e)
       .then(e => {
@@ -220,7 +236,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when before changes output', () => {
+  test('throws error if before method returns value that does not pass typeCheck', () => {
     return resolveEntity('model:c.5', 'some string')
       .catch(e => e)
       .then(e => {
@@ -228,7 +244,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when model:before changes output', () => {
+  test('throws error if middleware before returns value that does not pass typeCheck', () => {
     dataPoint.middleware.use('model:before', (acc, next) => {
       acc.resolve(1)
       next(null)
@@ -241,7 +257,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when global before middleware changes output', () => {
+  test('throws error if global before middleware returns value that does not pass typeCheck', () => {
     dataPoint.middleware.use('before', (acc, next) => {
       acc.resolve(1)
       next(null)
@@ -254,7 +270,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when after changes output', () => {
+  test('throws error if after method returns value that does not pass typeCheck', () => {
     return resolveEntity('model:c.4', 'some string')
       .catch(e => e)
       .then(e => {
@@ -262,7 +278,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when model:after changes output', () => {
+  test('throws error if after middleware returns value that does not pass typeCheck', () => {
     dataPoint.middleware.use('model:after', (acc, next) => {
       acc.resolve(1)
       next(null)
@@ -275,7 +291,7 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - throws error if outputType does not pass when global after middleware changes output', () => {
+  test('throws error if global after middleware returns value that does not pass typeCheck', () => {
     dataPoint.middleware.use('after', (acc, next) => {
       acc.resolve(1)
       next(null)
@@ -288,37 +304,37 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
-  test('outputType - typeCheck passes if error method returns value with correct type', () => {
+  test('passes if error method returns value with correct type', () => {
     return resolveEntity('model:c.6', 'string').then(acc => {
       expect(acc.value).toBe('error string')
     })
   })
 
-  test('outputType - typeCheck fails if error method returns value with incorrect type', () => {
+  test('throws if error method does not return value with correct type', () => {
     return resolveEntity('model:c.7', 'string').catch(e => {
       expect(e).toMatchSnapshot()
     })
   })
 
-  test('outputType - typeCheck is bypassed if error method throws error', () => {
+  test('is bypassed if error throws error', () => {
     return resolveEntity('model:c.8', 'string').catch(e => {
       expect(e).toMatchSnapshot()
     })
   })
 
-  test('outputType - if typeCheck passes then resolve normal', () => {
+  test('resolves normally if typeCheck passes', () => {
     return resolveEntity('model:c.1', 'foo').then(ac => {
       expect(ac.value).toEqual('foo')
     })
   })
 
-  test('typeCheck should not be able to change acc.value', () => {
+  test('does not change acc.value', () => {
     return resolveEntity('model:c.2', 'my string').then(result => {
       expect(result.value).toEqual('my string')
     })
   })
 
-  test('if custom typeCheck throws then fail', () => {
+  test('throws error if custom typeCheck fails', () => {
     return resolveEntity('model:c.3', 123)
       .catch(e => e)
       .then(result => {

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -220,6 +220,40 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
+  test('outputType - throws error if outputType does not pass when before changes output', () => {
+    return resolveEntity('model:c.5', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
+  test('outputType - throws error if outputType does not pass when model:before changes output', () => {
+    dataPoint.middleware.use('model:before', (acc, next) => {
+      acc.resolve(1)
+      next(null)
+    })
+
+    return resolveEntity('model:c.1', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
+  test('outputType - throws error if outputType does not pass when global before middleware changes output', () => {
+    dataPoint.middleware.use('before', (acc, next) => {
+      acc.resolve(1)
+      next(null)
+    })
+
+    return resolveEntity('model:c.1', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
   test('outputType - throws error if outputType does not pass when after changes output', () => {
     return resolveEntity('model:c.4', 'some string')
       .catch(e => e)
@@ -230,6 +264,19 @@ describe('ResolveEntity.resolveEntity', () => {
 
   test('outputType - throws error if outputType does not pass when model:after changes output', () => {
     dataPoint.middleware.use('model:after', (acc, next) => {
+      acc.resolve(1)
+      next(null)
+    })
+
+    return resolveEntity('model:c.1', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
+  test('outputType - throws error if outputType does not pass when global after middleware changes output', () => {
+    dataPoint.middleware.use('after', (acc, next) => {
       acc.resolve(1)
       next(null)
     })

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -311,15 +311,19 @@ describe('ResolveEntity.resolveEntity outputType', () => {
   })
 
   test('throws if error method does not return value with correct type', () => {
-    return resolveEntity('model:c.7', 'string').catch(e => {
-      expect(e).toMatchSnapshot()
-    })
+    return resolveEntity('model:c.7', 'string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
   })
 
   test('is bypassed if error throws error', () => {
-    return resolveEntity('model:c.8', 'string').catch(e => {
-      expect(e).toMatchSnapshot()
-    })
+    return resolveEntity('model:c.8', 'string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
   })
 
   test('passes if error method catches typeCheck errors and returns value', () => {
@@ -329,14 +333,16 @@ describe('ResolveEntity.resolveEntity outputType', () => {
   })
 
   test('fails if error method catches typeCheck errors and returns bad value', () => {
-    return resolveEntity('model:c.10', 'string').catch(error => {
-      expect(error).toMatchSnapshot()
-    })
+    return resolveEntity('model:c.10', 'string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
   })
 
   test('resolves normally if typeCheck passes', () => {
-    return resolveEntity('model:c.1', 'foo').then(ac => {
-      expect(ac.value).toEqual('foo')
+    return resolveEntity('model:c.1', 'foo').then(acc => {
+      expect(acc.value).toEqual('foo')
     })
   })
 

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -228,6 +228,19 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
+  test('outputType - throws error if outputType does not pass when model:after changes output', () => {
+    dataPoint.middleware.use('model:after', (acc, next) => {
+      acc.resolve(1)
+      next(null)
+    })
+
+    return resolveEntity('model:c.1', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
   test('outputType - if typeCheck passes then resolve normal', () => {
     return resolveEntity('model:c.1', 'foo').then(ac => {
       expect(ac.value).toEqual('foo')

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -220,6 +220,14 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
+  test('outputType - throws error if outputType does not pass when after changes output', () => {
+    return resolveEntity('model:c.4', 'some string')
+      .catch(e => e)
+      .then(e => {
+        expect(e).toMatchSnapshot()
+      })
+  })
+
   test('outputType - if typeCheck passes then resolve normal', () => {
     return resolveEntity('model:c.1', 'foo').then(ac => {
       expect(ac.value).toEqual('foo')

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -288,6 +288,24 @@ describe('ResolveEntity.resolveEntity', () => {
       })
   })
 
+  test('outputType - typeCheck passes if error method returns value with correct type', () => {
+    return resolveEntity('model:c.6', 'string').then(acc => {
+      expect(acc.value).toBe('error string')
+    })
+  })
+
+  test('outputType - typeCheck fails if error method returns value with incorrect type', () => {
+    return resolveEntity('model:c.7', 'string').catch(e => {
+      expect(e).toMatchSnapshot()
+    })
+  })
+
+  test('outputType - typeCheck is bypassed if error method throws error', () => {
+    return resolveEntity('model:c.8', 'string').catch(e => {
+      expect(e).toMatchSnapshot()
+    })
+  })
+
   test('outputType - if typeCheck passes then resolve normal', () => {
     return resolveEntity('model:c.1', 'foo').then(ac => {
       expect(ac.value).toEqual('foo')

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -322,6 +322,18 @@ describe('ResolveEntity.resolveEntity outputType', () => {
     })
   })
 
+  test('passes if error method catches typeCheck errors and returns value', () => {
+    return resolveEntity('model:c.9', 'string').then(acc => {
+      expect(acc.value).toBe('string from error')
+    })
+  })
+
+  test('fails if error method catches typeCheck errors and returns bad value', () => {
+    return resolveEntity('model:c.10', 'string').catch(error => {
+      expect(error).toMatchSnapshot()
+    })
+  })
+
   test('resolves normally if typeCheck passes', () => {
     return resolveEntity('model:c.1', 'foo').then(ac => {
       expect(ac.value).toEqual('foo')

--- a/packages/data-point/test/definitions/model.js
+++ b/packages/data-point/test/definitions/model.js
@@ -38,5 +38,10 @@ module.exports = {
   'model:c.4': {
     after: input => 1,
     outputType: 'string'
+  },
+
+  'model:c.5': {
+    before: input => 1,
+    outputType: 'string'
   }
 }

--- a/packages/data-point/test/definitions/model.js
+++ b/packages/data-point/test/definitions/model.js
@@ -43,5 +43,31 @@ module.exports = {
   'model:c.5': {
     before: input => 1,
     outputType: 'string'
+  },
+
+  'model:c.6': {
+    before: () => {
+      throw new Error()
+    },
+    error: () => 'error string',
+    outputType: 'string'
+  },
+
+  'model:c.7': {
+    before: () => {
+      throw new Error()
+    },
+    error: () => 1,
+    outputType: 'string'
+  },
+
+  'model:c.8': {
+    before: () => {
+      throw new Error('error from before method')
+    },
+    error: error => {
+      throw error
+    },
+    outputType: 'string'
   }
 }

--- a/packages/data-point/test/definitions/model.js
+++ b/packages/data-point/test/definitions/model.js
@@ -69,5 +69,17 @@ module.exports = {
       throw error
     },
     outputType: 'string'
+  },
+
+  'model:c.9': {
+    before: () => 1,
+    error: () => 'string from error',
+    outputType: 'string'
+  },
+
+  'model:c.10': {
+    before: () => 1,
+    error: () => 2,
+    outputType: 'string'
   }
 }

--- a/packages/data-point/test/definitions/model.js
+++ b/packages/data-point/test/definitions/model.js
@@ -33,5 +33,10 @@ module.exports = {
 
       return value
     }
+  },
+
+  'model:c.4': {
+    after: input => 1,
+    outputType: 'string'
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Moves the `inputType` and `outputType` resolution to the beginning/end of the entity resolution.

<!-- Why are these changes necessary? -->
**Why**: Closes #202

<!-- How were these changes implemented? -->
**How**: just moved the lines really.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->