### PR TITLE
Mock console.info from request entity being forced to err

### DIFF
--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -393,6 +393,7 @@ describe('resolve', () => {
   })
 
   test('it should omit options.auth when encountering an error', () => {
+    console.info = jest.fn()
     nock('http://remote.test')
       .get('/source1')
       .reply(404)
@@ -400,6 +401,7 @@ describe('resolve', () => {
     return transform('request:a9', {}).catch(err => {
       expect(err.statusCode).toEqual(404)
       expect(err.message).toMatchSnapshot()
+      expect(console.info).toBeCalled()
 
       // credentials are still available in the raw error.options
       expect(err.options.auth).toEqual({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Mock `console.info` so that the "helpful" information is hidden in the test output

<!-- Why are these changes necessary? -->
**Why**: When entitiy-requests encounter an error we log info to the console and it looks ugly in the test output

<!-- How were these changes implemented? -->
**How**: `jest.fn()`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
 
Perhaps we should remove/gate the `console.info` in the source, but until we do this is really annoying. Keep in mind that even though we mocked out `console.info`, our users will still see this message in their test output if they are testing for requests encountering an error. We've mocked all the logging out of the tests, it seems silly to leave it for users to be annoyed.