### PR TITLE
feat(data-point): Refactor behavior of find, filter, and empty reducers

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -642,7 +642,7 @@ Example at: [examples/reducer-function-error.js](examples/reducer-function-error
 
 ### <a name="object-reducer">ObjectReducer</a>
 
-These are plain objects where the values are reducers. They're used to aggregate data or transform objects. For values that should be constants instead of reducers, you can use the [constant](#reducer-constant) reducer helper.
+These are plain objects where the value of each key is a [reducer](#reducers). They're used to aggregate data or transform objects. For values that should be constants instead of reducers, you can use the [constant](#reducer-constant) reducer helper.
 
 <details>
   <summary>Transforming an object</summary>
@@ -858,7 +858,7 @@ A ListReducer is an array of reducers where the result of each reducer becomes t
 | `['$a.b', (input) => { ... }]` | Get path `a.b`, pipe value to function reducer |
 | `['$a.b', (input) => { ... }, 'hash:Foo']` | Get path `a.b`, pipe value to function reducer, pipe result to `hash:Foo` |
 
-An empty `ListReducer` will resolve to `undefined`:
+**IMPORTANT**: an empty `ListReducer` will resolve to `undefined`. This mirrors the behavior of empty functions.
 
 ```js
 const reducer = []

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -642,7 +642,7 @@ Example at: [examples/reducer-function-error.js](examples/reducer-function-error
 
 ### <a name="object-reducer">ObjectReducer</a>
 
-ObjectReducers are plain objects where the values are reducers. They're used to aggregate data or transform objects. For values that should be constants instead of reducers, you can use the [constant](#reducer-constant) reducer helper.
+These are plain objects where the values are reducers. They're used to aggregate data or transform objects. For values that should be constants instead of reducers, you can use the [constant](#reducer-constant) reducer helper.
 
 <details>
   <summary>Transforming an object</summary>
@@ -790,6 +790,16 @@ Each of the reducers might contain more ObjectReducers (which might contain redu
   ```
 </details>
 
+An empty `ObjectReducer` will resolve to an empty object:
+
+```js
+const reducer = {}
+
+const input = { a: 1 }
+
+dataPoint.resolve(reducer, input) // => {}
+```
+
 ### <a name="entity-reducer">EntityReducer</a>
 
 An EntityReducer is the actual implementation of an entity. When implementing an EntityReducer, you are actually passing the current [Accumulator](#accumulator) Object to an entity spec, to become its current Accumulator object.
@@ -847,6 +857,16 @@ A ListReducer is an array of reducers where the result of each reducer becomes t
 |:---|:---|
 | `['$a.b', (input) => { ... }]` | Get path `a.b`, pipe value to function reducer |
 | `['$a.b', (input) => { ... }, 'hash:Foo']` | Get path `a.b`, pipe value to function reducer, pipe result to `hash:Foo` |
+
+An empty `ListReducer` will resolve to `undefined`:
+
+```js
+const reducer = []
+
+const input = 'INPUT'
+
+dataPoint.resolve(reducer, input) // => undefined
+```
 
 ### <a name="reducer-conditional-operator">Conditionally execute an entity</a>
 

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -14,7 +14,7 @@ const utils = require('../../utils')
  */
 function resolveErrorReducers (manager, error, accumulator, resolveReducer) {
   const errorReducer = accumulator.reducer.spec.error
-  if (utils.reducerIsEmpty(errorReducer)) {
+  if (!errorReducer) {
     return Promise.reject(error)
   }
 

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -20,13 +20,13 @@ afterEach(() => {
 })
 
 describe('ResolveEntity.resolveErrorReducers', () => {
-  test('It should reject if no transform set', () => {
+  test('It should reject if no reducer is provided', () => {
     const err = new Error('Test')
     const accumulator = helpers.createAccumulator(
       {},
       {
         context: {
-          error: createReducer([])
+          error: null
         }
       }
     )
@@ -43,7 +43,7 @@ describe('ResolveEntity.resolveErrorReducers', () => {
       })
   })
 
-  test('It should handle if transform set', () => {
+  test('It should handle error if reducer is provided', () => {
     const err = new Error('Test')
     const accumulator = helpers.createAccumulator(
       {},

--- a/packages/data-point/lib/entity-types/entity-collection/factory.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.js
@@ -46,8 +46,9 @@ function create (spec, id) {
 
   const composeSpec = parseCompose.parse(spec, modifierKeys)
   parseCompose.validateCompose(entity.id, composeSpec, modifierKeys)
-
-  entity.compose = createCompose(composeSpec)
+  if (composeSpec.length) {
+    entity.compose = createCompose(composeSpec)
+  }
 
   return Object.freeze(entity)
 }

--- a/packages/data-point/lib/entity-types/entity-collection/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/factory.test.js
@@ -11,7 +11,7 @@ test('modelFactory#create default', () => {
   expect(result.params).toEqual({})
 
   expect(result).not.toHaveProperty('value')
-  expect(helpers.isReducer(result.compose)).toBe(true)
+  expect(result.compose).toBeUndefined()
 })
 
 describe('parse loose modifiers', () => {

--- a/packages/data-point/lib/entity-types/entity-collection/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-collection/resolve.js
@@ -5,19 +5,10 @@ const _ = require('lodash')
 const utils = require('../../utils')
 
 /**
- * @param {Accumulator} accumulator
- * @param {reducer} composeReducer
- * @param {Function} resolveReducer
+ * NOTE: as expensive as this might be, this is to avoid 'surprises'
+ * @param {Accumulator} acc
+ * @return {Promise<Accumulator>}
  */
-function resolveCompose (accumulator, composeReducer, resolveReducer) {
-  if (utils.reducerIsEmpty(composeReducer)) {
-    return Promise.resolve(accumulator)
-  }
-
-  return resolveReducer(accumulator, composeReducer)
-}
-
-// NOTE: as expensive as this might be, this is to avoid 'surprises'
 function validateAsArray (acc) {
   const entity = acc.reducer.spec
   return acc.value instanceof Array
@@ -46,7 +37,7 @@ function resolve (accumulator, resolveReducer) {
 
   return resolveReducer(accumulator, entity.value)
     .then(acc => validateAsArray(acc))
-    .then(acc => resolveCompose(acc, entity.compose, resolveReducer))
+    .then(acc => resolveReducer(acc, entity.compose))
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
@@ -73,7 +73,7 @@ describe('entity.collection.map', () => {
     })
   })
 
-  test('should return undefined values if map reducer is empty list', () => {
+  test('should return array with undefined elements if map reducer is empty list', () => {
     return transform('collection:b.2', testData).then(acc => {
       expect(acc.value).toEqual([undefined, undefined, undefined])
     })

--- a/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-collection/resolve.test.js
@@ -36,9 +36,7 @@ beforeEach(() => {
 describe('CollectionReducer.resolve', () => {
   test('entity.collection - only process Plain Objects', () => {
     return transform('collection:ObjectsNotAllowed', testData)
-      .catch(result => {
-        return result
-      })
+      .catch(err => err)
       .then(result => {
         expect(result).toBeInstanceOf(Error)
       })
@@ -75,10 +73,9 @@ describe('entity.collection.map', () => {
     })
   })
 
-  // NOTE: to skip map execution when map is empty
-  test('should skip Map Transform if empty', () => {
+  test('should return undefined values if map reducer is empty list', () => {
     return transform('collection:b.2', testData).then(acc => {
-      expect(acc.value).toEqual([1, 2, 3])
+      expect(acc.value).toEqual([undefined, undefined, undefined])
     })
   })
 })
@@ -100,10 +97,9 @@ describe('entity.collection.filter', () => {
     })
   })
 
-  // NOTE: to skip map execution when filter is empty
-  test('it should skip filter transform if empty', () => {
+  test('should return empty array if filter reducer is empty list', () => {
     return transform('collection:c.3', testData).then(acc => {
-      expect(acc.value).toEqual([1, 2, 3])
+      expect(acc.value).toEqual([])
     })
   })
 })
@@ -121,10 +117,9 @@ describe('entity.collection.find', () => {
     })
   })
 
-  // NOTE: to skip map execution when find is empty
-  test('should skip Find Transform if empty', () => {
+  test('should return undefined if find reducer is empty list', () => {
     return transform('collection:d.3', testData).then(acc => {
-      expect(acc.value).toEqual([1, 2, 3])
+      expect(acc.value).toEqual(undefined)
     })
   })
 })
@@ -144,7 +139,7 @@ describe('entity.collection.compose', () => {
 
   test('map should handle error and rethrow with appended information', () => {
     return transform('collection:j.3', testData)
-      .catch(acc => acc)
+      .catch(err => err)
       .then(acc => {
         expect(acc).toBeInstanceOf(Error)
       })
@@ -152,7 +147,7 @@ describe('entity.collection.compose', () => {
 
   test('find should handle error and rethrow with appended information', () => {
     return transform('collection:j.4', testData)
-      .catch(acc => acc)
+      .catch(err => err)
       .then(acc => {
         expect(acc).toBeInstanceOf(Error)
       })
@@ -160,7 +155,7 @@ describe('entity.collection.compose', () => {
 
   test('filter should handle error and rethrow with appended information', () => {
     return transform('collection:j.5', testData)
-      .catch(acc => acc)
+      .catch(err => err)
       .then(acc => {
         expect(acc).toBeInstanceOf(Error)
       })

--- a/packages/data-point/lib/entity-types/entity-hash/factory.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.js
@@ -65,7 +65,9 @@ function create (spec, id) {
 
   const compose = parseCompose.parse(spec, modifierKeys)
   parseCompose.validateCompose(entity.id, compose, modifierKeys)
-  entity.compose = createCompose(compose)
+  if (compose.length) {
+    entity.compose = createCompose(compose)
+  }
 
   return Object.freeze(entity)
 }

--- a/packages/data-point/lib/entity-types/entity-hash/factory.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/factory.test.js
@@ -11,8 +11,7 @@ test('factory#create default', () => {
   expect(result).not.toHaveProperty('after')
   expect(result).not.toHaveProperty('value')
   expect(result.params).toEqual({})
-
-  expect(helpers.isReducer(result.compose)).toBe(true)
+  expect(result.compose).toBeUndefined()
 })
 
 describe('factory#parse loose modifiers', () => {

--- a/packages/data-point/lib/entity-types/entity-hash/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-hash/resolve.js
@@ -4,19 +4,10 @@ const utils = require('../../utils')
 const Util = require('util')
 
 /**
- * @param {Accumulator} accumulator
- * @param {reducer} composeReducer
- * @param {Function} resolveReducer
+ * NOTE: as expensive as this might be, this is to avoid 'surprises'
+ * @param {Accumulator} acc
+ * @return {Promise<Accumulator>}
  */
-function resolveCompose (accumulator, composeReducer, resolveReducer) {
-  if (utils.reducerIsEmpty(composeReducer)) {
-    return Promise.resolve(accumulator)
-  }
-
-  return resolveReducer(accumulator, composeReducer)
-}
-
-// NOTE: as expensive as this might be, this is to avoid 'surprises'
 function validateAsObject (acc) {
   const entity = acc.reducer.spec
   if (_.isPlainObject(acc.value)) {
@@ -46,7 +37,7 @@ function resolve (accumulator, resolveReducer) {
 
   return resolveReducer(accumulator, entity.value)
     .then(validateAsObject)
-    .then(acc => resolveCompose(acc, entity.compose, resolveReducer))
+    .then(acc => resolveReducer(acc, entity.compose))
 }
 
 module.exports.resolve = resolve

--- a/packages/data-point/lib/entity-types/entity-hash/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-hash/resolve.test.js
@@ -68,9 +68,9 @@ describe('entity.hash.mapKeys', () => {
       expect(acc.value).toEqual({ h: 2 })
     })
   })
-  test('do nothing if mapKeys is empty', () => {
+  test('returns empty object if mapKeys is empty', () => {
     return transform('hash:b.2', testData).then(acc => {
-      expect(acc.value).toEqual({ g1: 1 })
+      expect(acc.value).toEqual({})
     })
   })
 })
@@ -117,9 +117,9 @@ describe('entity.hash.pickKeys', () => {
       })
     })
   })
-  test('it should do nothing if pickKeys is empty', () => {
+  test('returns empty object if pickKeys is empty', () => {
     return transform('hash:e.2', testData).then(acc => {
-      expect(acc.value).toEqual({ g1: 1 })
+      expect(acc.value).toEqual({})
     })
   })
 })

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
@@ -1,5 +1,5 @@
 const utils = require('../../../utils')
-const { reducerOutputIsFalsy } = require('../utils')
+const { isFalsy } = require('../utils')
 
 /**
  * @param {Accumulator} accumulator
@@ -8,7 +8,7 @@ const { reducerOutputIsFalsy } = require('../utils')
  */
 function resolve (accumulator, _default) {
   let value = accumulator.value
-  if (reducerOutputIsFalsy(value)) {
+  if (isFalsy(value)) {
     value = typeof _default === 'function' ? _default() : _default
   }
 

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-default/resolve.js
@@ -1,17 +1,5 @@
 const utils = require('../../../utils')
-
-/**
- * @param {*} value
- * @return {boolean}
- */
-function isFalsy (value) {
-  return (
-    value === null ||
-    typeof value === 'undefined' ||
-    Number.isNaN(value) ||
-    value === ''
-  )
-}
+const { reducerOutputIsFalsy } = require('../utils')
 
 /**
  * @param {Accumulator} accumulator
@@ -20,7 +8,7 @@ function isFalsy (value) {
  */
 function resolve (accumulator, _default) {
   let value = accumulator.value
-  if (isFalsy(value)) {
+  if (reducerOutputIsFalsy(value)) {
     value = typeof _default === 'function' ? _default() : _default
   }
 

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-filter/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-filter/resolve.js
@@ -1,5 +1,7 @@
 const Promise = require('bluebird')
+
 const utils = require('../../../utils')
+const { reducerPredicateIsTruthy } = require('../utils')
 
 /**
  * @param {Object} manager
@@ -10,14 +12,10 @@ const utils = require('../../../utils')
  */
 function resolve (manager, resolveReducer, accumulator, reducerFilter) {
   const reducer = reducerFilter.reducer
-  if (utils.reducerIsEmpty(reducer)) {
-    return Promise.resolve(accumulator)
-  }
-
   return Promise.filter(accumulator.value, itemValue => {
     const itemContext = utils.set(accumulator, 'value', itemValue)
     return resolveReducer(manager, itemContext, reducer).then(res => {
-      return !!res.value
+      return reducerPredicateIsTruthy(reducer, res.value)
     })
   }).then(result => utils.set(accumulator, 'value', result))
 }

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-filter/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-filter/resolve.test.js
@@ -16,17 +16,13 @@ beforeAll(() => {
 })
 
 describe('ReducerFilter#resolve', () => {
-  test('It should return the accumulator when resolver is empty', () => {
-    const value = [
-      {
-        a: 1
-      }
-    ]
+  test('It should return empty array when reducer is empty reducer list', () => {
+    const value = [true, true]
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
       result => {
-        expect(result.value).toEqual(value)
+        expect(result.value).toEqual([])
       }
     )
   })
@@ -51,5 +47,73 @@ describe('ReducerFilter#resolve', () => {
         ])
       }
     )
+  })
+
+  describe('ReducerFind#resolve with reducer objects', () => {
+    test('it should filter values that resolve with falsy keys', () => {
+      const value = [
+        {
+          a: undefined
+        },
+        {
+          a: 'undefined'
+        },
+        {
+          a: null
+        },
+        {
+          a: ''
+        },
+        {
+          a: 0
+        },
+        {
+          a: 'hello'
+        },
+        {
+          a: 5
+        },
+        {
+          a: NaN
+        },
+        {
+          a: []
+        },
+        {
+          a: {}
+        }
+      ]
+      const accumulator = AccumulatorFactory.create({ value })
+      const reducer = Factory.create(Reducer.create, {
+        a: '$a'
+      })
+      return Resolve.resolve(
+        manager,
+        Reducer.resolve,
+        accumulator,
+        reducer
+      ).then(result => {
+        expect(result.value).toEqual([
+          {
+            a: 'undefined'
+          },
+          {
+            a: 0
+          },
+          {
+            a: 'hello'
+          },
+          {
+            a: 5
+          },
+          {
+            a: []
+          },
+          {
+            a: {}
+          }
+        ])
+      })
+    })
   })
 })

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-find/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-find/resolve.js
@@ -1,5 +1,7 @@
 const Promise = require('bluebird')
+
 const utils = require('../../../utils')
+const { reducerPredicateIsTruthy } = require('../utils')
 
 /**
  * @param {Object} manager
@@ -9,11 +11,11 @@ const utils = require('../../../utils')
  * @returns {Promise<Accumulator>}
  */
 function resolve (manager, resolveReducer, accumulator, reducerFind) {
-  const reducer = reducerFind.reducer
-  if (utils.reducerIsEmpty(reducer)) {
-    return Promise.resolve(accumulator)
+  if (accumulator.value.length === 0) {
+    return Promise.resolve(utils.set(accumulator, 'value', undefined))
   }
 
+  const reducer = reducerFind.reducer
   return Promise.reduce(
     accumulator.value,
     (result, itemValue) => {
@@ -21,7 +23,9 @@ function resolve (manager, resolveReducer, accumulator, reducerFind) {
       return (
         result ||
         resolveReducer(manager, itemContext, reducer).then(res => {
-          return res.value ? itemValue : undefined
+          return reducerPredicateIsTruthy(reducer, res.value)
+            ? itemValue
+            : undefined
         })
       )
     },

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-find/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-find/resolve.test.js
@@ -16,17 +16,13 @@ beforeAll(() => {
 })
 
 describe('ReducerFind#resolve', () => {
-  test('It should return the accumulator when resolver is empty', () => {
-    const value = [
-      {
-        a: 1
-      }
-    ]
+  test('It should return undefined when input is an empty array', () => {
+    const value = []
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
       result => {
-        expect(result.value).toEqual(value)
+        expect(result.value).toBeUndefined()
       }
     )
   })
@@ -65,6 +61,61 @@ describe('ReducerFind#resolve', () => {
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
       result => {
         expect(result.value).toBeUndefined()
+      }
+    )
+  })
+})
+
+describe('ReducerFind#resolve with reducer objects', () => {
+  test('it should not find a match when keys are null or undefined', () => {
+    const value = [
+      {
+        a: undefined,
+        b: undefined
+      },
+      {
+        a: null,
+        b: null
+      }
+    ]
+    const accumulator = AccumulatorFactory.create({ value })
+    const reducer = Factory.create(Reducer.create, {
+      a: '$a',
+      b: '$b'
+    })
+    return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
+      result => {
+        expect(result.value).toBeUndefined()
+      }
+    )
+  })
+  test('it should match the item with truthy keys', () => {
+    const value = [
+      {
+        a: true,
+        b: undefined
+      },
+      {
+        a: true,
+        b: ''
+      },
+      {
+        a: null,
+        b: true
+      },
+      {
+        a: 'a truthy string',
+        b: true
+      }
+    ]
+    const accumulator = AccumulatorFactory.create({ value })
+    const reducer = Factory.create(Reducer.create, {
+      a: '$a',
+      b: '$b'
+    })
+    return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
+      result => {
+        expect(result.value).toEqual(value[3])
       }
     )
   })

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.js
@@ -10,10 +10,6 @@ const utils = require('../../../utils')
  */
 function resolve (manager, resolveReducer, accumulator, reducerMap) {
   const reducer = reducerMap.reducer
-  if (utils.reducerIsEmpty(reducer)) {
-    return Promise.resolve(accumulator)
-  }
-
   return Promise.map(accumulator.value, itemValue => {
     const itemContext = utils.set(accumulator, 'value', itemValue)
     return resolveReducer(manager, itemContext, reducer).then(res => {

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.test.js
@@ -16,7 +16,7 @@ beforeAll(() => {
 })
 
 describe('ReducerMap#resolve', () => {
-  test('It should return undefined values when reducer is empty list', () => {
+  test('It should return array with undefined elements when reducer is empty list', () => {
     const value = [true, true]
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-map/resolve.test.js
@@ -16,17 +16,13 @@ beforeAll(() => {
 })
 
 describe('ReducerMap#resolve', () => {
-  test('It should return the accumulator when resolver is empty', () => {
-    const value = [
-      {
-        a: 1
-      }
-    ]
+  test('It should return undefined values when reducer is empty list', () => {
+    const value = [true, true]
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
       result => {
-        expect(result.value).toEqual(value)
+        expect(result.value).toEqual([undefined, undefined])
       }
     )
   })

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-omit/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-omit/resolve.js
@@ -12,10 +12,6 @@ const utils = require('../../../utils')
  */
 function resolve (manager, resolveReducer, accumulator, reducerOmit) {
   const keys = reducerOmit.keys
-  if (keys.length === 0) {
-    return Promise.resolve(accumulator)
-  }
-
   const value = omit(accumulator.value, keys)
   return Promise.resolve(utils.set(accumulator, 'value', value))
 }

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-omit/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-omit/resolve.test.js
@@ -17,11 +17,10 @@ beforeAll(() => {
 
 describe('ReducerOmit#resolve', () => {
   test('It should return the accumulator when no keys are provided', () => {
-    const value = [
-      {
-        a: 1
-      }
-    ]
+    const value = {
+      a: 1,
+      b: 2
+    }
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-pick/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-pick/resolve.js
@@ -11,10 +11,6 @@ const utils = require('../../../utils')
  */
 function resolve (manager, resolveReducer, accumulator, reducerPick) {
   const keys = reducerPick.keys
-  if (keys.length === 0) {
-    return Promise.resolve(accumulator)
-  }
-
   const value = pick(accumulator.value, keys)
   return Promise.resolve(utils.set(accumulator, 'value', value))
 }

--- a/packages/data-point/lib/reducer-types/reducer-helpers/reducer-pick/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/reducer-pick/resolve.test.js
@@ -16,17 +16,16 @@ beforeAll(() => {
 })
 
 describe('ReducerPick#resolve', () => {
-  test('It should return the accumulator when no keys are provided', () => {
-    const value = [
-      {
-        a: 1
-      }
-    ]
+  test('It should return an empty object when no keys are provided', () => {
+    const value = {
+      a: 1,
+      b: 2
+    }
     const accumulator = AccumulatorFactory.create({ value })
     const reducer = Factory.create(Reducer.create, [])
     return Resolve.resolve(manager, Reducer.resolve, accumulator, reducer).then(
       result => {
-        expect(result.value).toEqual(value)
+        expect(result.value).toEqual({})
       }
     )
   })

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
@@ -1,0 +1,44 @@
+const last = require('lodash/last')
+
+/**
+ * used by ReducerDefault to check
+ * when the default should be used
+ * @param {*} value
+ * @return {boolean}
+ */
+function reducerOutputIsFalsy (value) {
+  return (
+    value === null ||
+    typeof value === 'undefined' ||
+    Number.isNaN(value) ||
+    value === ''
+  )
+}
+
+module.exports.reducerOutputIsFalsy = reducerOutputIsFalsy
+
+/**
+ * used by ReducerFilter and ReducerFind
+ * @param {Reducer} reducer
+ * @param {*} output
+ * @return {boolean}
+ */
+function reducerPredicateIsTruthy (reducer, output) {
+  if (reducer.type === 'ReducerList') {
+    reducer = last(reducer.reducers) || {}
+  }
+
+  if (reducer.type === 'ReducerObject') {
+    const keys = Object.keys(output)
+    return (
+      !!keys.length &&
+      keys.every(key => {
+        return !reducerOutputIsFalsy(output[key])
+      })
+    )
+  }
+
+  return !!output
+}
+
+module.exports.reducerPredicateIsTruthy = reducerPredicateIsTruthy

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
@@ -26,12 +26,12 @@ function reducerPredicateIsTruthy (reducer, output) {
   // this, combined with the second conditional, is needed
   // when the last reducer in a list is a ReducerObject
   if (reducer.type === 'ReducerList') {
-    reducer = last(reducer.reducers) || {}
+    reducer = last(reducer.reducers)
   }
 
   // when a ReducerObject is used as a predicate, the
   // output is truthy when all the values are truthy
-  if (reducer.type === 'ReducerObject') {
+  if (reducer && reducer.type === 'ReducerObject') {
     const keys = Object.keys(output)
     return !!keys.length && keys.every(key => !isFalsy(output[key]))
   }

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.js
@@ -6,7 +6,7 @@ const last = require('lodash/last')
  * @param {*} value
  * @return {boolean}
  */
-function reducerOutputIsFalsy (value) {
+function isFalsy (value) {
   return (
     value === null ||
     typeof value === 'undefined' ||
@@ -15,27 +15,25 @@ function reducerOutputIsFalsy (value) {
   )
 }
 
-module.exports.reducerOutputIsFalsy = reducerOutputIsFalsy
+module.exports.isFalsy = isFalsy
 
 /**
- * used by ReducerFilter and ReducerFind
  * @param {Reducer} reducer
  * @param {*} output
  * @return {boolean}
  */
 function reducerPredicateIsTruthy (reducer, output) {
+  // this, combined with the second conditional, is needed
+  // when the last reducer in a list is a ReducerObject
   if (reducer.type === 'ReducerList') {
     reducer = last(reducer.reducers) || {}
   }
 
+  // when a ReducerObject is used as a predicate, the
+  // output is truthy when all the values are truthy
   if (reducer.type === 'ReducerObject') {
     const keys = Object.keys(output)
-    return (
-      !!keys.length &&
-      keys.every(key => {
-        return !reducerOutputIsFalsy(output[key])
-      })
-    )
+    return !!keys.length && keys.every(key => !isFalsy(output[key]))
   }
 
   return !!output

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
@@ -3,56 +3,138 @@
 const utils = require('./index')
 
 describe('utils#isFalsy', () => {
-  expect(utils.isFalsy(null)).toBe(true)
-  expect(utils.isFalsy(undefined)).toBe(true)
-  expect(utils.isFalsy(NaN)).toBe(true)
-  expect(utils.isFalsy('')).toBe(true)
-  expect(utils.isFalsy('undefined')).toBe(false)
-  expect(utils.isFalsy({})).toBe(false)
-  expect(utils.isFalsy([])).toBe(false)
-  expect(utils.isFalsy(0)).toBe(false)
-  expect(utils.isFalsy(false)).toBe(false)
-  expect(utils.isFalsy(true)).toBe(false)
-})
-
-describe('utils#reducerPredicateIsTruthy', () => {
-  test('with ReducerList', () => {
-    const reducer = { type: 'ReducerList' }
-    expect(utils.reducerPredicateIsTruthy(reducer, undefined)).toBe(false)
-    expect(utils.reducerPredicateIsTruthy(reducer, false)).toBe(false)
-    expect(utils.reducerPredicateIsTruthy(reducer, '')).toBe(false)
-    expect(utils.reducerPredicateIsTruthy(reducer, 0)).toBe(false)
-    expect(utils.reducerPredicateIsTruthy(reducer, true)).toBe(true)
-    expect(utils.reducerPredicateIsTruthy(reducer, 'undefined')).toBe(true)
+  test('returns true when input is null', () => {
+    expect(utils.isFalsy(null)).toBe(true)
   })
 
-  test('with ReducerObject', () => {
-    const reducer = { type: 'ReducerObject' }
-    expect(utils.reducerPredicateIsTruthy(reducer, {})).toBe(false)
+  test('returns true when input is undefined', () => {
+    expect(utils.isFalsy(undefined)).toBe(true)
+  })
+
+  test('returns true when input is NaN', () => {
+    expect(utils.isFalsy(NaN)).toBe(true)
+  })
+
+  test("returns true when input is ''", () => {
+    expect(utils.isFalsy('')).toBe(true)
+  })
+
+  test("returns false when input is 'undefined'", () => {
+    expect(utils.isFalsy('undefined')).toBe(false)
+  })
+
+  test('returns false when input is {}', () => {
+    expect(utils.isFalsy({})).toBe(false)
+  })
+
+  test('returns false when input is []', () => {
+    expect(utils.isFalsy([])).toBe(false)
+  })
+
+  test('returns false when input is 0', () => {
+    expect(utils.isFalsy(0)).toBe(false)
+  })
+
+  test('returns false when input is false', () => {
+    expect(utils.isFalsy(false)).toBe(false)
+  })
+
+  test('returns false when input is true', () => {
+    expect(utils.isFalsy(true)).toBe(false)
+  })
+})
+
+describe('utils#reducerPredicateIsTruthy with ReducerList', () => {
+  test('returns false when output is undefined', () => {
     expect(
-      utils.reducerPredicateIsTruthy(reducer, {
-        a: true,
-        b: true
-      })
-    ).toBe(true)
-    expect(
-      utils.reducerPredicateIsTruthy(reducer, {
-        a: false,
-        b: true
-      })
-    ).toBe(true)
-    expect(
-      utils.reducerPredicateIsTruthy(reducer, {
-        a: true,
-        b: ''
-      })
+      utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, undefined)
     ).toBe(false)
+  })
+
+  test('returns false when output is false', () => {
+    expect(utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, false)).toBe(
+      false
+    )
+  })
+
+  test("returns false when output is ''", () => {
+    expect(utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, '')).toBe(
+      false
+    )
+  })
+
+  test('returns false when output is 0', () => {
+    expect(utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, 0)).toBe(
+      false
+    )
+  })
+
+  test('returns true when output is true', () => {
+    expect(utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, true)).toBe(
+      true
+    )
+  })
+
+  test("returns true when output is 'undefined'", () => {
     expect(
-      utils.reducerPredicateIsTruthy(reducer, {
-        a: true,
-        b: undefined
-      })
+      utils.reducerPredicateIsTruthy({ type: 'ReducerList' }, 'undefined')
+    ).toBe(true)
+  })
+})
+
+describe('utils#reducerPredicateIsTruthy with ReducerObject', () => {
+  test('returns false when output is {}', () => {
+    expect(utils.reducerPredicateIsTruthy({ type: 'ReducerObject' }, {})).toBe(
+      false
+    )
+  })
+
+  test('returns false when output has an empty string as a value', () => {
+    expect(
+      utils.reducerPredicateIsTruthy(
+        { type: 'ReducerObject' },
+        {
+          a: true,
+          b: ''
+        }
+      )
     ).toBe(false)
+  })
+
+  test('returns false when output has undefined as a value', () => {
+    expect(
+      utils.reducerPredicateIsTruthy(
+        { type: 'ReducerObject' },
+        {
+          a: true,
+          b: undefined
+        }
+      )
+    ).toBe(false)
+  })
+
+  test('returns true when output values are true', () => {
+    expect(
+      utils.reducerPredicateIsTruthy(
+        { type: 'ReducerObject' },
+        {
+          a: true,
+          b: true
+        }
+      )
+    ).toBe(true)
+  })
+
+  test('returns true when output values are either true or false', () => {
+    expect(
+      utils.reducerPredicateIsTruthy(
+        { type: 'ReducerObject' },
+        {
+          a: false,
+          b: true
+        }
+      )
+    ).toBe(true)
   })
 
   test('with ReducerObject as first item in a ReducerList', () => {

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
@@ -2,17 +2,17 @@
 
 const utils = require('./index')
 
-describe('utils#reducerOutputIsFalsy', () => {
-  expect(utils.reducerOutputIsFalsy(null)).toBe(true)
-  expect(utils.reducerOutputIsFalsy(undefined)).toBe(true)
-  expect(utils.reducerOutputIsFalsy(NaN)).toBe(true)
-  expect(utils.reducerOutputIsFalsy('')).toBe(true)
-  expect(utils.reducerOutputIsFalsy('undefined')).toBe(false)
-  expect(utils.reducerOutputIsFalsy({})).toBe(false)
-  expect(utils.reducerOutputIsFalsy([])).toBe(false)
-  expect(utils.reducerOutputIsFalsy(0)).toBe(false)
-  expect(utils.reducerOutputIsFalsy(false)).toBe(false)
-  expect(utils.reducerOutputIsFalsy(true)).toBe(false)
+describe('utils#isFalsy', () => {
+  expect(utils.isFalsy(null)).toBe(true)
+  expect(utils.isFalsy(undefined)).toBe(true)
+  expect(utils.isFalsy(NaN)).toBe(true)
+  expect(utils.isFalsy('')).toBe(true)
+  expect(utils.isFalsy('undefined')).toBe(false)
+  expect(utils.isFalsy({})).toBe(false)
+  expect(utils.isFalsy([])).toBe(false)
+  expect(utils.isFalsy(0)).toBe(false)
+  expect(utils.isFalsy(false)).toBe(false)
+  expect(utils.isFalsy(true)).toBe(false)
 })
 
 describe('utils#reducerPredicateIsTruthy', () => {

--- a/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-helpers/utils/index.test.js
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+
+const utils = require('./index')
+
+describe('utils#reducerOutputIsFalsy', () => {
+  expect(utils.reducerOutputIsFalsy(null)).toBe(true)
+  expect(utils.reducerOutputIsFalsy(undefined)).toBe(true)
+  expect(utils.reducerOutputIsFalsy(NaN)).toBe(true)
+  expect(utils.reducerOutputIsFalsy('')).toBe(true)
+  expect(utils.reducerOutputIsFalsy('undefined')).toBe(false)
+  expect(utils.reducerOutputIsFalsy({})).toBe(false)
+  expect(utils.reducerOutputIsFalsy([])).toBe(false)
+  expect(utils.reducerOutputIsFalsy(0)).toBe(false)
+  expect(utils.reducerOutputIsFalsy(false)).toBe(false)
+  expect(utils.reducerOutputIsFalsy(true)).toBe(false)
+})
+
+describe('utils#reducerPredicateIsTruthy', () => {
+  test('with ReducerList', () => {
+    const reducer = { type: 'ReducerList' }
+    expect(utils.reducerPredicateIsTruthy(reducer, undefined)).toBe(false)
+    expect(utils.reducerPredicateIsTruthy(reducer, false)).toBe(false)
+    expect(utils.reducerPredicateIsTruthy(reducer, '')).toBe(false)
+    expect(utils.reducerPredicateIsTruthy(reducer, 0)).toBe(false)
+    expect(utils.reducerPredicateIsTruthy(reducer, true)).toBe(true)
+    expect(utils.reducerPredicateIsTruthy(reducer, 'undefined')).toBe(true)
+  })
+
+  test('with ReducerObject', () => {
+    const reducer = { type: 'ReducerObject' }
+    expect(utils.reducerPredicateIsTruthy(reducer, {})).toBe(false)
+    expect(
+      utils.reducerPredicateIsTruthy(reducer, {
+        a: true,
+        b: true
+      })
+    ).toBe(true)
+    expect(
+      utils.reducerPredicateIsTruthy(reducer, {
+        a: false,
+        b: true
+      })
+    ).toBe(true)
+    expect(
+      utils.reducerPredicateIsTruthy(reducer, {
+        a: true,
+        b: ''
+      })
+    ).toBe(false)
+    expect(
+      utils.reducerPredicateIsTruthy(reducer, {
+        a: true,
+        b: undefined
+      })
+    ).toBe(false)
+  })
+
+  test('with ReducerObject as first item in a ReducerList', () => {
+    const reducer = {
+      type: 'ReducerList',
+      reducers: [
+        {
+          type: 'ReducerObject'
+        },
+        {
+          type: 'ReducerPath'
+        }
+      ]
+    }
+    expect(utils.reducerPredicateIsTruthy(reducer, {})).toBe(true)
+  })
+
+  test('with ReducerObject as last item in a ReducerList', () => {
+    const reducer = {
+      type: 'ReducerList',
+      reducers: [
+        {
+          type: 'ReducerPath'
+        },
+        {
+          type: 'ReducerObject'
+        }
+      ]
+    }
+    expect(utils.reducerPredicateIsTruthy(reducer, {})).toBe(false)
+  })
+})

--- a/packages/data-point/lib/reducer-types/reducer-list/factory.js
+++ b/packages/data-point/lib/reducer-types/reducer-list/factory.js
@@ -12,7 +12,6 @@ module.exports.type = REDUCER_LIST
  */
 function ReducerList () {
   this.type = 'ReducerList'
-  this.isEmpty = undefined
   this.reducers = []
 }
 
@@ -79,12 +78,11 @@ module.exports.parse = parse
  * @param {Array} source
  * @return {reducer}
  */
-function create (createReducer, source = []) {
+function create (createReducer, source) {
   const tokens = parse(source)
   const reducers = tokens.map(token => createReducer(token))
 
   const reducer = new ReducerList()
-  reducer.isEmpty = _.isEmpty(reducers)
   reducer.reducers = reducers
 
   return reducer

--- a/packages/data-point/lib/reducer-types/reducer-list/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-list/resolve.js
@@ -1,5 +1,7 @@
 const Promise = require('bluebird')
 
+const utils = require('../../utils')
+
 /**
  * @param {Object} manager
  * @param {Function} resolveReducer
@@ -10,7 +12,7 @@ const Promise = require('bluebird')
 function resolve (manager, resolveReducer, accumulator, reducerList) {
   const reducers = reducerList.reducers
   if (reducers.length === 0) {
-    return Promise.resolve(accumulator)
+    return Promise.resolve(utils.set(accumulator, 'value', undefined))
   }
 
   const result = Promise.reduce(

--- a/packages/data-point/lib/reducer-types/reducer-list/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-list/resolve.test.js
@@ -17,22 +17,22 @@ beforeAll(() => {
   manager = fixtureStore.create()
 })
 
-test('resolve#reducer.resolve - reducer empty', () => {
-  const accumulator = AccumulatorFactory.create({
-    value: testData.a.g
+describe('resolve#reducer.resolve - with valid reducers', () => {
+  test('empty reducer list should return undefined', () => {
+    const accumulator = AccumulatorFactory.create({
+      value: true
+    })
+
+    const reducerList = createReducerList(createReducer, [])
+
+    return resolveReducerList(
+      manager,
+      resolveReducer,
+      accumulator,
+      reducerList
+    ).then(result => expect(result.value).toBeUndefined())
   })
 
-  const reducerList = createReducerList(createReducer, '')
-
-  return resolveReducerList(
-    manager,
-    resolveReducer,
-    accumulator,
-    reducerList
-  ).then(result => expect(result.value).toEqual(testData.a.g))
-})
-
-describe('resolve#reducer.resolve - with valid reducers', () => {
   test('one reducer', () => {
     const accumulator = AccumulatorFactory.create({
       value: testData

--- a/packages/data-point/lib/reducer-types/reducer-object/__snapshots__/factory.test.js.snap
+++ b/packages/data-point/lib/reducer-types/reducer-object/__snapshots__/factory.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ReducerObject.factory#create reducer object with no props argument 1`] = `
 ReducerObject {
-  "isEmpty": true,
   "reducers": Array [],
   "source": [Function],
   "type": "ReducerObject",
@@ -11,7 +10,6 @@ ReducerObject {
 
 exports[`ReducerObject.factory#create reducer object with props argument 1`] = `
 ReducerObject {
-  "isEmpty": false,
   "reducers": Array [
     Object {
       "path": Array [
@@ -74,7 +72,6 @@ Object {
         "a2",
       ],
       "reducer": ReducerList {
-        "isEmpty": false,
         "reducers": Array [
           ReducerPath {
             "asCollection": false,
@@ -99,7 +96,6 @@ Object {
         "b2",
       ],
       "reducer": ReducerObject {
-        "isEmpty": false,
         "reducers": Array [
           Object {
             "path": Array [

--- a/packages/data-point/lib/reducer-types/reducer-object/factory.js
+++ b/packages/data-point/lib/reducer-types/reducer-object/factory.js
@@ -13,7 +13,6 @@ module.exports.type = REDUCER_OBJECT
  */
 function ReducerObject () {
   this.type = REDUCER_OBJECT
-  this.isEmpty = undefined
   this.source = undefined
   this.reducers = undefined
 }
@@ -93,7 +92,6 @@ function create (createReducer, source = {}) {
   const props = getProps(createReducer, source)
 
   const reducer = new ReducerObject()
-  reducer.isEmpty = _.isEmpty(props.constants) && _.isEmpty(props.reducers)
   reducer.source = getSourceFunction(props.constants)
   reducer.reducers = props.reducers
 

--- a/packages/data-point/lib/reducer-types/reducer-object/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-object/resolve.js
@@ -11,10 +11,6 @@ const utils = require('../../utils')
  * @returns {Promise<Accumulator>}
  */
 function resolve (manager, resolveReducer, accumulator, reducer) {
-  if (utils.reducerIsEmpty(reducer)) {
-    return Promise.resolve(accumulator)
-  }
-
   return Promise.map(reducer.reducers, ({ reducer, path }) => {
     return resolveReducer(manager, accumulator, reducer).then(({ value }) => ({
       path,

--- a/packages/data-point/lib/reducer-types/reducer-object/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-object/resolve.test.js
@@ -15,7 +15,7 @@ beforeAll(() => {
 })
 
 describe('resolve#reducerObject.resolve', () => {
-  it('should return an empty object when the reducer object is an empty', () => {
+  it('should return an empty object when the reducer object is empty', () => {
     const reducer = createReducerObject(createReducer, {})
 
     const accumulator = AccumulatorFactory.create({

--- a/packages/data-point/lib/reducer-types/reducer-object/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-object/resolve.test.js
@@ -15,7 +15,7 @@ beforeAll(() => {
 })
 
 describe('resolve#reducerObject.resolve', () => {
-  it('should return the accumulator for an empty reducer object', () => {
+  it('should return an empty object when the reducer object is an empty', () => {
     const reducer = createReducerObject(createReducer, {})
 
     const accumulator = AccumulatorFactory.create({
@@ -34,7 +34,7 @@ describe('resolve#reducerObject.resolve', () => {
       accumulator,
       reducer
     ).then(result => {
-      expect(result.value).toEqual(accumulator.value)
+      expect(result.value).toEqual({})
     })
   })
 

--- a/packages/data-point/lib/utils/index.js
+++ b/packages/data-point/lib/utils/index.js
@@ -87,16 +87,6 @@ function inspectProperties (obj, props, indent = '') {
 
 module.exports.inspectProperties = inspectProperties
 
-/**
- * @param {reducer} reducer
- * @returns {boolean}
- */
-function reducerIsEmpty (reducer) {
-  return !reducer || !!reducer.isEmpty
-}
-
-module.exports.reducerIsEmpty = reducerIsEmpty
-
 function isFalsy (val) {
   return val === null || val === false || typeof val === 'undefined'
 }

--- a/packages/data-point/lib/utils/utils.test.js
+++ b/packages/data-point/lib/utils/utils.test.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash')
 const utils = require('./index')
-const createReducer = require('../reducer-types/factory').create
 
 describe('utils.set', () => {
   const target = { b: 1 }
@@ -118,19 +117,6 @@ describe('inspectProperties', () => {
     expect(
       utils.inspectProperties(obj, ['a', 'b', 'c'], '  ')
     ).toMatchSnapshot()
-  })
-})
-
-describe('reducerIsEmpty', () => {
-  test('It should test for empty reducers', () => {
-    expect(utils.reducerIsEmpty()).toEqual(true)
-    expect(utils.reducerIsEmpty(null)).toEqual(true)
-    expect(utils.reducerIsEmpty(createReducer([]))).toEqual(true)
-    expect(utils.reducerIsEmpty(createReducer({}))).toEqual(true)
-    expect(utils.reducerIsEmpty(createReducer('$a'))).toEqual(false)
-    expect(utils.reducerIsEmpty(createReducer(['$a']))).toEqual(false)
-    expect(utils.reducerIsEmpty(createReducer(['$a', '$a']))).toEqual(false)
-    expect(utils.reducerIsEmpty(createReducer({ a: '$a' }))).toEqual(false)
   })
 })
 


### PR DESCRIPTION
**What**: closes #122  and closes #176

1. Passing a `ReducerObject` to `ReducerFind` or `ReducerFilter` no longer just returns the first item in the array
2. Changed the behavior of "empty" reducers (before, they just returned the unchanged accumulator)
 - Resolving an empty `ReducerList` will return `undefined`
 - Resolving an empty `ReducerObject` will return `{}`
 - Resolving a `ReducerPick` that doesn't have any keys will return `{}`
5. Do not add empty `compose` properties to `hash` or `collection` entities
6. Removes the `reducerIsEmpty` function, because it was hard to maintain as we add more reducer types

**Why**: Does not cover up "empty" reducers, so that users are encouraged to write cleaner code

**How**: Refactor the `resolve` functions for several reducer types

**Checklist**:
- [x] Has Breaking changes
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
