### PR TITLE
feat(data-point): Expose createReducer on DataPoint object

### DIFF
--- a/packages/data-point/lib/__snapshots__/index.test.js.snap
+++ b/packages/data-point/lib/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`lib It should explicity expose set of methods 1`] = `
 Object {
   "create": [Function],
   "createEntity": [Function],
+  "createReducer": [Function],
   "createReducerResolver": [Function],
   "helpers": Object {
     "assign": [Function],

--- a/packages/data-point/lib/core/transform.js
+++ b/packages/data-point/lib/core/transform.js
@@ -19,13 +19,7 @@ function reducerResolve (manager, reducerSource, value, options) {
     values: manager.values.getStore()
   })
 
-  let reducer
-  if (Reducer.isReducer(reducerSource)) {
-    reducer = reducerSource
-  } else {
-    reducer = Reducer.create(reducerSource)
-  }
-
+  const reducer = Reducer.create(reducerSource)
   return Reducer.resolve(manager, context, reducer)
 }
 

--- a/packages/data-point/lib/core/transform.js
+++ b/packages/data-point/lib/core/transform.js
@@ -19,7 +19,12 @@ function reducerResolve (manager, reducerSource, value, options) {
     values: manager.values.getStore()
   })
 
-  const reducer = Reducer.create(reducerSource)
+  let reducer
+  if (Reducer.isReducer(reducerSource)) {
+    reducer = reducerSource
+  } else {
+    reducer = Reducer.create(reducerSource)
+  }
 
   return Reducer.resolve(manager, context, reducer)
 }

--- a/packages/data-point/lib/core/transform.test.js
+++ b/packages/data-point/lib/core/transform.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-const core = require('./core')
+const DataPoint = require('../index')
 
 const reducers = require('../../test/utils/reducers')
 const entities = require('../../test/definitions/entities')
@@ -11,7 +11,7 @@ const TestData = require('../../test/data.json')
 let dataPoint
 
 beforeAll(() => {
-  dataPoint = core.create({
+  dataPoint = DataPoint.create({
     values: {
       v1: 'v1'
     },
@@ -197,6 +197,18 @@ describe('resolve', () => {
       .then(Transform.resolve(dataPoint, '$foo'))
       .then(value => {
         expect(value).toEqual('bar')
+      })
+  })
+})
+
+describe('dataPoint.createReducer', () => {
+  test('it should evaluate an existing reducer', () => {
+    const reducer = DataPoint.createReducer(['$a', input => input + 1])
+    return dataPoint
+      .resolve(reducer, { a: 5 })
+      .catch(err => err)
+      .then(output => {
+        expect(output).toBe(6)
       })
   })
 })

--- a/packages/data-point/lib/index.js
+++ b/packages/data-point/lib/index.js
@@ -10,5 +10,6 @@ module.exports = {
   resolveEntity: helpers.resolveEntity,
   reducify: helpers.reducify,
   reducifyAll: helpers.reducifyAll,
+  createReducer: helpers.createReducer,
   createReducerResolver: helpers.reducifyAll
 }

--- a/packages/data-point/lib/reducer-types/factory.js
+++ b/packages/data-point/lib/reducer-types/factory.js
@@ -52,6 +52,10 @@ function normalizeInput (source) {
  * @return {reducer}
  */
 function createReducer (source, options = {}) {
+  if (isReducer(source)) {
+    return source
+  }
+
   source = normalizeInput(source)
   const reducerType = reducerTypes.find(r => r.isType(source))
 

--- a/packages/data-point/lib/reducer-types/factory.test.js
+++ b/packages/data-point/lib/reducer-types/factory.test.js
@@ -35,6 +35,20 @@ describe('reducer#create', () => {
     expect(reducer.entityType).toBe('fooEntity')
   })
 
+  test('return the input when the input is already a reducer', () => {
+    const reducer1 = Factory.create('$test')
+    const reducer2 = Factory.create(reducer1)
+    expect(reducer1 === reducer2).toBe(true)
+    expect(reducer1).toEqual(reducer2)
+  })
+
+  test('do not modify an existing reducer in the source for a ReducerList', () => {
+    const reducer1 = Factory.create('$bar')
+    const reducer2 = Factory.create(['$foo', reducer1])
+    expect(reducer1 === reducer2.reducers[1]).toBe(true)
+    expect(reducer1).toEqual(reducer2.reducers[1])
+  })
+
   test('detect invalid', () => {
     expect(() => {
       Factory.create('a')


### PR DESCRIPTION
also allow existing reducers to be passed to resolve and transform functions

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: closes #233

<!-- How were these changes implemented? -->
**How**: Exports `createReducer` function and refactors `reducerResolve` 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->