### PR TITLE
refactor(data-point): Do not try to execute undefined entity lifecycle methods

### DIFF
--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -120,7 +120,7 @@ function typeCheck (manager, accumulator, reducer, resolveReducer) {
  * @param {Accumulator} accumulator
  * @param {Function} reducer
  * @param {Function} mainResolver
- * @returns {Promise}
+ * @returns {Promise<Accumulator>}
  */
 function resolveEntity (
   manager,
@@ -206,7 +206,7 @@ function resolveEntity (
       // attach entity information to help debug
       error.entityId = currentAccumulator.reducer.spec.id
 
-      let result = resolveErrorReducers(
+      let errorResult = resolveErrorReducers(
         manager,
         error,
         currentAccumulator,
@@ -214,12 +214,12 @@ function resolveEntity (
       )
 
       if (outputType) {
-        result = result.then(acc => {
+        errorResult = errorResult.then(acc => {
           return typeCheck(manager, acc, outputType, resolveReducer)
         })
       }
 
-      return result
+      return errorResult
     })
     .then(resultContext => {
       if (trace === true) {
@@ -240,7 +240,7 @@ module.exports.resolveEntity = resolveEntity
  * @param {Accumulator} accumulator
  * @param {Function} reducer
  * @param {Function} mainResolver
- * @returns {Promise}
+ * @returns {Promise<Accumulator>}
  */
 function resolve (manager, resolveReducer, accumulator, reducer, mainResolver) {
   const hasEmptyConditional = reducer.hasEmptyConditional

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -9,7 +9,7 @@ const utils = require('../../utils')
  * @param {Error} error
  * @param {Accumulator} accumulator
  * @param {Function} resolveReducer
- * @returns {Promise}
+ * @returns {Promise<Accumulator>}
  */
 function resolveErrorReducers (manager, error, accumulator, resolveReducer) {
   const errorReducer = accumulator.reducer.spec.error

--- a/packages/data-point/lib/entity-types/base-entity/resolve.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.js
@@ -91,7 +91,7 @@ function resolveMiddleware (manager, promise, name) {
         err.name = 'bypass'
         err.bypass = true
         err.bypassValue = middlewareResult
-        return Promise.reject(err)
+        throw err
       }
 
       return middlewareResult

--- a/packages/data-point/lib/entity-types/base-entity/resolve.test.js
+++ b/packages/data-point/lib/entity-types/base-entity/resolve.test.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 
+const Promise = require('bluebird')
+
 const ResolveEntity = require('./resolve')
 const createReducer = require('../../reducer-types').create
 const resolveReducer = require('../../reducer-types').resolve
@@ -102,11 +104,11 @@ describe('ResolveEntity.resolveMiddleware', () => {
       next(null)
     })
 
-    const racc = helpers.createAccumulator('foo')
+    const acc = helpers.createAccumulator('foo')
     return ResolveEntity.resolveMiddleware(
       dataPoint,
-      'request:before',
-      racc
+      Promise.resolve(acc),
+      'request:before'
     ).then(acc => {
       expect(acc.value).toEqual('bar')
     })
@@ -118,8 +120,12 @@ describe('ResolveEntity.resolveMiddleware', () => {
       next(null)
     })
 
-    const racc = helpers.createAccumulator('foo')
-    return ResolveEntity.resolveMiddleware(dataPoint, 'request:before', racc)
+    const acc = helpers.createAccumulator('foo')
+    return ResolveEntity.resolveMiddleware(
+      dataPoint,
+      Promise.resolve(acc),
+      'request:before'
+    )
       .catch(reason => reason)
       .then(reason => {
         expect(reason).toBeInstanceOf(Error)

--- a/packages/data-point/lib/middleware-control/middleware.js
+++ b/packages/data-point/lib/middleware-control/middleware.js
@@ -9,7 +9,7 @@ const Promise = require('bluebird')
  * @return {*}
  */
 function run (accumulator, stackSpec, done) {
-  if (stackSpec.length === 0) {
+  if (!stackSpec || stackSpec.length === 0) {
     return done(null, accumulator)
   }
 

--- a/packages/data-point/lib/middleware/resolve.js
+++ b/packages/data-point/lib/middleware/resolve.js
@@ -1,5 +1,3 @@
-const Promise = require('bluebird')
-
 const middlewareContextFactory = require('../middleware-context')
 const middlewareControl = require('../middleware-control')
 
@@ -9,7 +7,7 @@ const middlewareControl = require('../middleware-control')
  * @return {Array}
  */
 function getStack (store, middlewareName) {
-  return store.get(middlewareName) || []
+  return store.get(middlewareName)
 }
 
 module.exports.getStack = getStack
@@ -21,13 +19,9 @@ module.exports.getStack = getStack
  * @return {Promise}
  */
 function resolve (manager, middlewareName, accumulator) {
+  const middlewareContext = middlewareContextFactory.create(accumulator)
   const stack = getStack(manager.middleware.store, middlewareName)
-  if (stack.length === 0) {
-    return Promise.resolve(accumulator)
-  }
-
-  accumulator = middlewareContextFactory.create(accumulator)
-  return middlewareControl(accumulator, stack)
+  return middlewareControl(middlewareContext, stack)
 }
 
 module.exports.resolve = resolve


### PR DESCRIPTION
**What**: Refactors the base-entity resolve function.

**Why**: Performance. I tested a simple entity with bench-trial, and the resolve time went from 19,530 ops/sec to 25,353 ops/sec, which is a ~30% improvement.


```js
'model:test': {
  value: () => true,
  outputType: 'boolean'
}
```

**How**:

Added conditionals in `base-entity/resolve.js` to make sure lifecycle methods / middleware are defined before trying to execute them (which extends the promise chain).

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation n/a
- [x] Tests
- [x] Ready to be merged