### PR TITLE
feat(data-point-service): deprecates cache.prefix

### DIFF
--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -30,8 +30,7 @@ Properties of the `options` argument:
 |:---|:---|:---|
 | **cache** | `Object` | cache specific settings |
 | **cache.isRequired** | `Boolean` | false by default, if true it will throw an error |
-| **cache.prefix** | `string` | by default [os.hostname()](https://nodejs.org/api/os.html#os_os_hostname), this will be the prefix of every cache key added to redis |
-| **cache.redis** | `Object` | redis settings passed to the [IORedis constructor](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) |
+| **cache.redis** | `Object` | **redis** settings passed to the [ioredis](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) constructor. For key prefixing, set [keyPrefix](https://github.com/luin/ioredis#transparent-key-prefixing) through `cache.redis.keyPrefix`; if the value is not provided then [os.hostname()](https://nodejs.org/api/os.html#os_os_hostname) will be used. |
 
 This method returns a Promise that resolves to a Service Object. 
 

--- a/packages/data-point-service/lib/__snapshots__/factory.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/factory.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getDefaultSettings should return default settings 1`] = `
+Object {
+  "cache": Object {
+    "isRequired": false,
+  },
+}
+`;
+
+exports[`prefixDeprecationError should warn when cache.prefix is set 1`] = `"options.cache.prefix is now deprecated, please use options.cache.redis.keyPrefix instead."`;

--- a/packages/data-point-service/lib/cache-middleware.js
+++ b/packages/data-point-service/lib/cache-middleware.js
@@ -7,12 +7,10 @@ const logger = require('./logger')
  * @param {DataPoint.Accumulator} ctx DataPoint Accumulator object
  * @returns {String} generated cache key
  */
-function generateKey (prefix, ctx) {
-  const cacheKey = ctx.context.params.cacheKey
+function generateKey (ctx) {
+  return ctx.context.params.cacheKey
     ? ctx.context.params.cacheKey(ctx)
     : `entity:${ctx.context.id}`
-
-  return `${prefix}:${cacheKey}`
 }
 
 /**
@@ -248,7 +246,7 @@ function before (service, ctx, next) {
     return next()
   }
 
-  const entryKey = generateKey(service.cachePrefix, ctx)
+  const entryKey = generateKey(ctx)
 
   Promise.resolve(staleWhileRevalidate)
     .then(isStaleWhileRevalidate => {
@@ -287,7 +285,7 @@ function after (service, ctx, next) {
   }
 
   // from here below ttl is assumed to be true
-  const entryKey = generateKey(service.cachePrefix, ctx)
+  const entryKey = generateKey(ctx)
 
   if (staleWhileRevalidate) {
     // if its at the process of revalidating, then lets skip any further calls

--- a/packages/data-point-service/lib/cache-middleware.test.js
+++ b/packages/data-point-service/lib/cache-middleware.test.js
@@ -21,7 +21,6 @@ function createMocks () {
   const set = jest.fn(() => Promise.resolve(true))
   const get = jest.fn(() => Promise.resolve(true))
   const service = {
-    cachePrefix: 'prefix',
     dataPoint: {
       resolveFromAccumulator
     },
@@ -41,10 +40,10 @@ function createMocks () {
 }
 
 describe('genrateKey', () => {
-  it('should generate default id with prefix', () => {
+  it('should generate default id', () => {
     const ctx = createContext()
-    const result = CacheMiddleware.generateKey('prefix', ctx)
-    expect(result).toEqual('prefix:entity:model:Foo')
+    const result = CacheMiddleware.generateKey(ctx)
+    expect(result).toEqual('entity:model:Foo')
   })
 
   it('should generate a key using cacheKey parameter', () => {
@@ -54,8 +53,8 @@ describe('genrateKey', () => {
       return `custom:${acc.context.id}`
     }
 
-    const result = CacheMiddleware.generateKey('prefix', ctx)
-    expect(result).toEqual('prefix:custom:model:Foo')
+    const result = CacheMiddleware.generateKey(ctx)
+    expect(result).toEqual('custom:model:Foo')
   })
 })
 
@@ -419,7 +418,7 @@ describe('before', () => {
     const next = () => {
       expect(spyResolveStaleWhileRevalidateEntry).toHaveBeenCalledWith(
         mocks.service,
-        'prefix:entity:model:Foo',
+        'entity:model:Foo',
         '20m',
         mocks.ctx
       )
@@ -435,9 +434,7 @@ describe('before', () => {
     mocks.service.cache.get = jest.fn()
 
     const next = jest.fn(() => {
-      expect(mocks.service.cache.get).toHaveBeenCalledWith(
-        'prefix:entity:model:Foo'
-      )
+      expect(mocks.service.cache.get).toHaveBeenCalledWith('entity:model:Foo')
       expect(next).toBeCalled()
       done()
     })
@@ -520,7 +517,7 @@ describe('after', () => {
     const next = () => {
       expect(setStaleWhileRevalidateEntry).toBeCalledWith(
         mocks.service,
-        'prefix:entity:model:Foo',
+        'entity:model:Foo',
         'VALUE',
         '20m'
       )
@@ -548,7 +545,7 @@ describe('after', () => {
     const next = () => {
       expect(setStaleWhileRevalidateEntry).not.toBeCalled()
       expect(mocks.service.cache.set).toBeCalledWith(
-        'prefix:entity:model:Foo',
+        'entity:model:Foo',
         'VALUE',
         '20m'
       )


### PR DESCRIPTION
use cache.redis.keyPrefix instead

BREAKING CHANGE: cache.prefix is no longer used, if set; an error is thrown to alert the user of the
change

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

deprecated `cache.prefix` in favor or `cache.redis.keyPrefix`

<!-- Why are these changes necessary? -->
**Why**:

There were two places where this was possible to be set, and the cache.prefix was not the right approach, prefixing should be delegated to native ioredis options.

<!-- How were these changes implemented? -->
**How**:

Removed the feature, added a check if the value is set, then throw an error to alert the user of the change.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Has Breaking changes
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
