### PR TITLE
Fix stale while revalidate stale ttl logic

### DIFF
--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -89,22 +89,24 @@ createService()
   .then(server)
 ```
 
-## <a name="entity-params-cache">Configure entity.params cache</a>
+## <a name="entity-params-cache">Configure entity's cache settings</a>
 
 To configure an entity's cache settings you must set cache configuration through the params object.
 
 ```js
 '<type>:<entity-name>': {
   params: {
-    ttl: String,
-    staleWhileRevalidate: Boolean
+    cache: {
+      ttl: String,
+      staleWhileRevalidate: Boolean
+    }
   }
 }
 ```
 
-### ttl
+### cache.ttl
 
-Use `ttl` to set an entity's cache entry **Time To Live** value. This value is expected to be written as a string following the format supported by [ms](https://www.npmjs.com/package/ms).
+Use `cache.ttl` to set an entity's cache entry **Time To Live** value. This value is expected to be written as a string following the format supported by [ms](https://www.npmjs.com/package/ms).
 
 **Example:**
 
@@ -117,16 +119,18 @@ DataPointService.create({
     'request:getPlanets': {
       url: 'https://swapi.co/api/planets/'
       params: {
-        ttl: '20m', // 20 minutes
+        cache: {
+          ttl: '20m', // 20 minutes
+        }
       }
     }
   }
 })
 ```
 
-### staleWhileRevalidate
+### cache.staleWhileRevalidate
 
-Use `staleWhileRevalidate` flag in conjunction with a valid `ttl` to use the Stale While Revalidate caching pattern. When this flag is set to `true` your entity will be resolved to a stale value until the ttl expires, revalidation happens in the background and is triggered only upon the key being requested and its ttl being expired.
+Use `cache.staleWhileRevalidate` flag in conjunction with a valid `cache.ttl` to use the Stale While Revalidate caching pattern. When this flag is set to `true` your entity will be resolved to a stale value until the ttl expires, revalidation happens in the background and is triggered only upon the key being requested and its ttl being expired.
 
 **Example:**
 
@@ -139,8 +143,10 @@ DataPointService.create({
     'request:getPlanets': {
       url: 'https://swapi.co/api/planets/'
       params: {
-        ttl: '20m', // 20 minutes
-        staleWhileRevalidate: true
+        cache: {
+          ttl: '20m', // 20 minutes
+          staleWhileRevalidate: true
+        }
       }
     }
   }

--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -97,14 +97,18 @@ To configure an entity's cache settings you must set cache configuration through
 '<type>:<entity-name>': {
   params: {
     cache: {
-      ttl: String,
-      staleWhileRevalidate: Boolean
+      ttl: String|Number,
+      staleWhileRevalidate: String|Number
     }
   }
 }
 ```
 
 ### cache.ttl
+
+```js
+ttl: String|Number
+```
 
 Use `cache.ttl` to set an entity's cache entry **Time To Live** value. This value is expected to be written as a string following the format supported by [ms](https://www.npmjs.com/package/ms).
 
@@ -130,7 +134,11 @@ DataPointService.create({
 
 ### cache.staleWhileRevalidate
 
-Use `cache.staleWhileRevalidate` flag in conjunction with a valid `cache.ttl` to use the Stale While Revalidate caching pattern. When this flag is set to `true` your entity will be resolved to a stale value until the ttl expires, revalidation happens in the background and is triggered only upon the key being requested and its ttl being expired.
+`staleWhileRevalidate = delta-seconds`
+
+`staleWhileRevalidate` value is expected to be written as a string following the format supported by [ms](https://www.npmjs.com/package/ms). Alternately it may also be set to `true`, which tells the entity to use double the time of the value of its `ttl`.
+
+Use `cache.staleWhileRevalidate` in conjunction with a valid `cache.ttl` to use the Stale While Revalidate cache pattern. When present, caches MAY serve the response in which it appears after it becomes stale, up to the indicated `ttl`. The cache SHOULD attempt to revalidate it asynchronously while still serving stale responses. If delta-seconds passes without the cached entity being revalidated, it SHOULD NOT continue to be served stale.
 
 **Example:**
 

--- a/packages/data-point-service/examples/express-cache-stale-while-revalidate.js
+++ b/packages/data-point-service/examples/express-cache-stale-while-revalidate.js
@@ -44,8 +44,10 @@ function createService () {
           return `Hello ${person}!!`
         },
         params: {
-          ttl: '10s',
-          staleWhileRevalidate: true
+          cache: {
+            ttl: '10s',
+            staleWhileRevalidate: true
+          }
         }
       }
     }

--- a/packages/data-point-service/examples/express-cache-stale-while-revalidate.js
+++ b/packages/data-point-service/examples/express-cache-stale-while-revalidate.js
@@ -45,8 +45,8 @@ function createService () {
         },
         params: {
           cache: {
-            ttl: '10s',
-            staleWhileRevalidate: true
+            ttl: '1m',
+            staleWhileRevalidate: '3m'
           }
         }
       }

--- a/packages/data-point-service/examples/express-simple-cache.js
+++ b/packages/data-point-service/examples/express-simple-cache.js
@@ -44,7 +44,9 @@ function createService () {
           return `Hello ${person}!!`
         },
         params: {
-          ttl: '10s'
+          cache: {
+            ttl: '10s'
+          }
         }
       }
     }

--- a/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
@@ -32,7 +32,7 @@ Array [
   Array [
     "SWI-STALE:key",
     undefined,
-    0,
+    400,
   ],
   Array [
     "SWI-CONTROL:key",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
#275

<!-- How were these changes implemented? -->
**How**:

Attempting to correctly implement the RFC https://tools.ietf.org/html/rfc5861#section-3

Enables staleWhileRevalidate to be `string` (ms) or `number`, it is now calculated as an addition to the given **ttl**.

to give backward compatibility with `boolean`, when set as `true` it will resolve to a **ttl** of twice as the given `cache.ttl`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
