### PR TITLE
fix(data-point-service): fix revalidation logic and key creation

### DIFF
--- a/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
@@ -30,13 +30,13 @@ Array [
 exports[`revalidateEntry should set cache 1`] = `
 Array [
   Array [
-    "SWI-STALE:key",
+    "key:swr.stale",
     undefined,
     400,
   ],
   Array [
-    "SWI-CONTROL:key",
-    "SWI-CONTROL",
+    "key:swr.control",
+    "SWR-CONTROL",
     200,
   ],
 ]


### PR DESCRIPTION
it now checks for revalidation cache key vs current cache key to prevent multiple revalidations

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

im sorry :) two bugs included in one single PR

- fixes revalidation logic
- changes key generation prefix to postfix

<!-- Why are these changes necessary? -->
**Why**:

- revalidation logic was not checking against being the same cache key, so it would essentially re-revalidate every single entity
- stale-while-revalidate key prefixes were not helping with the taxonomy of the key

<!-- How were these changes implemented? -->
**How**:

- we check against the cache key being revalidated and the current one, only if it matches
- moving the stale-while-revalidate key from prefix to postfix allows us to filter by anything preceding it

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
