### PR TITLE
Replaced remaining toThrowError calls with toThrowErrorMatchingSnapshot

### DIFF
--- a/packages/data-point-express/lib/__snapshots__/route-map.test.js.snap
+++ b/packages/data-point-express/lib/__snapshots__/route-map.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addRoute It should throw error if invalid method 1`] = `"Route undefined has an invalid method (foo), try using GET, POST, DELETE or PUT instead."`;
+
 exports[`verifyMiddlewareFormat should not be empty 1`] = `"Route Foo - middleware property must not be empty"`;
 
 exports[`verifyMiddlewareFormat throw error if entityId is not the last middleware 1`] = `"Route Foo - entityId middleware may only be at the end of the chain"`;

--- a/packages/data-point-express/lib/__snapshots__/router-middleware.test.js.snap
+++ b/packages/data-point-express/lib/__snapshots__/router-middleware.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`setupRoutes It should error if routes are missing 1`] = `"Routes option must be provided"`;

--- a/packages/data-point-express/lib/route-map.test.js
+++ b/packages/data-point-express/lib/route-map.test.js
@@ -248,7 +248,7 @@ describe('addRoute', () => {
         method: 'foo'
       }
       RouteMap.addRoute(createApp(), '/api', route, () => {})
-    }).toThrowError()
+    }).toThrowErrorMatchingSnapshot()
   })
 
   test('It should add a route', () => {

--- a/packages/data-point-express/lib/router-middleware.test.js
+++ b/packages/data-point-express/lib/router-middleware.test.js
@@ -30,7 +30,7 @@ describe('setupRoutes', () => {
   test('It should error if routes are missing', () => {
     expect(() => {
       RouterMiddleware.setupRouter()
-    }).toThrow()
+    }).toThrowErrorMatchingSnapshot()
   })
 })
 

--- a/packages/data-point-service/lib/__snapshots__/data-point-factory.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/data-point-factory.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`verify It should throw error if entities not provided 1`] = `"DataPoint options.entities should not be Empty"`;

--- a/packages/data-point-service/lib/__snapshots__/factory.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/factory.test.js.snap
@@ -8,4 +8,6 @@ Object {
 }
 `;
 
+exports[`handleCacheError It should throw error if cache is required 1`] = `"error"`;
+
 exports[`prefixDeprecationError should warn when cache.prefix is set 1`] = `"options.cache.prefix is now deprecated, please use options.cache.redis.keyPrefix instead."`;

--- a/packages/data-point-service/lib/data-point-factory.test.js
+++ b/packages/data-point-service/lib/data-point-factory.test.js
@@ -29,7 +29,7 @@ describe('verify', () => {
       DataPointFactory.verify({
         DataPoint
       })
-    }).toThrowError(/entities/)
+    }).toThrowErrorMatchingSnapshot()
   })
 })
 

--- a/packages/data-point-service/lib/factory.test.js
+++ b/packages/data-point-service/lib/factory.test.js
@@ -171,7 +171,7 @@ describe('handleCacheError', () => {
         isCacheRequired: true,
         settings: {}
       })
-    }).toThrowError('error')
+    }).toThrowErrorMatchingSnapshot()
   })
 
   test('It should set isCacheAvailable as false if not error not thrown', () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Replaced toThrowError calls with toThrowErrorMatchingSnapshot

<!-- Why are these changes necessary? -->
**Why**:  So we know what kinda of error is being thrown automatically with Jest's snapshots instead of hard coding what kind of error a test should produce.

<!-- How were these changes implemented? -->
**How**: Replaced all instances of toThrowError() with toThrowErrorMatchingSnapshot()

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
