### PR TITLE
feat(data-point-cache): adds delete functionality

### DIFF
--- a/packages/data-point-cache/lib/cache.js
+++ b/packages/data-point-cache/lib/cache.js
@@ -8,13 +8,26 @@ const DefaultSettings = {
   localTTL: ms('2s')
 }
 
+/**
+ * @param {String|Number} value
+ * @returns {Number}
+ */
+function normalizeMilliseconds (value) {
+  return typeof value === 'string' ? ms(value) : value
+}
+
 function set (cache, key, value, ttl = '20m') {
-  const ttlms = typeof ttl === 'string' ? ms(ttl) : ttl
+  const ttlms = normalizeMilliseconds(ttl)
   return cache.redis
     .set(key, value, ttlms)
     .then(res => cache.local.set(key, value, cache.settings.localTTL))
 }
 
+/**
+ * @param {Object} cache cache store
+ * @param {String} key cache key
+ * @returns {Promise<*|undefined>} returns value whenr esolved or undefined
+ */
 function getFromStore (cache, key) {
   return Promise.resolve(cache.local.get(key)).then(entry => {
     // if we still have it sotred locally return the value, skip everything else
@@ -29,6 +42,7 @@ function getFromStore (cache, key) {
         return
       }
 
+      // update local cache (short ttl) for any consecutive calls
       cache.local.set(key, value, cache.settings.localTTL)
 
       return value
@@ -39,15 +53,28 @@ function getFromStore (cache, key) {
 function get (cache, key) {
   return cache.redis.exists(key).then(exists => {
     if (exists) {
-      return getFromStore(cache, key)
+      return module.exports.getFromStore(cache, key)
     }
     return cache.local.del(key)
   })
 }
 
+/**
+ * @param {Object} cache cache object instance
+ * @param {Srtring} key cache key
+ */
+function del (cache, key) {
+  return cache.redis.del(key)
+}
+
+/**
+ * Decorates the cache object to add the API
+ * @param {Object} cache object to be decorated
+ */
 function bootstrapAPI (cache) {
   cache.set = set.bind(null, cache)
   cache.get = get.bind(null, cache)
+  cache.del = del.bind(null, cache)
   return cache
 }
 
@@ -58,7 +85,8 @@ function create (options) {
     redis: null,
     local: null,
     set: null,
-    get: null
+    get: null,
+    del: null
   }
   return Promise.resolve(Cache)
     .then(cache => {
@@ -75,8 +103,11 @@ function create (options) {
 }
 
 module.exports = {
+  normalizeMilliseconds,
   create,
   bootstrapAPI,
+  getFromStore,
   set,
-  get
+  get,
+  del
 }

--- a/packages/data-point-cache/lib/cache.test.js
+++ b/packages/data-point-cache/lib/cache.test.js
@@ -1,0 +1,175 @@
+/* eslint-env jest */
+
+jest.mock('ioredis', () => {
+  return require('ioredis-mock')
+})
+
+const _ = require('lodash')
+const Cache = require('./cache')
+
+beforeEach(() => {
+  jest.resetModules()
+  jest.resetAllMocks()
+})
+
+describe('cache.normalizeMilliseconds', () => {
+  it('should normalize to number if string provided', () => {
+    expect(Cache.normalizeMilliseconds('10ms')).toEqual(10)
+  })
+  it('should pass as is if not string', () => {
+    expect(Cache.normalizeMilliseconds(100)).toEqual(100)
+  })
+})
+
+describe('cache.set', () => {
+  it('should set in redis store', () => {
+    const redisSet = jest.fn(() => Promise.resolve(true))
+    const localSet = jest.fn(() => Promise.resolve(true))
+
+    const cache = {}
+    _.set(cache, 'redis.set', redisSet)
+    _.set(cache, 'local.set', localSet)
+    _.set(cache, 'settings.localTTL', 1000)
+
+    return Cache.set(cache, 'key', 'value', '10ms').then(() => {
+      expect(redisSet).toBeCalledWith('key', 'value', 10)
+      expect(localSet).toBeCalledWith('key', 'value', 1000)
+    })
+  })
+
+  it('should set in redis store with default ttl settings.localTTL when not provided', () => {
+    const redisSet = jest.fn(() => Promise.resolve(true))
+    const localSet = jest.fn(() => Promise.resolve(true))
+
+    const cache = {}
+    _.set(cache, 'redis.set', redisSet)
+    _.set(cache, 'local.set', localSet)
+    _.set(cache, 'settings.localTTL', 1000)
+
+    return Cache.set(cache, 'key', 'value').then(() => {
+      expect(redisSet).toBeCalledWith('key', 'value', 1200000)
+      expect(localSet).toBeCalledWith('key', 'value', 1000)
+    })
+  })
+})
+
+describe('del', () => {
+  it('should delete a key', () => {
+    const placeholder = {
+      redis: {
+        del: jest.fn()
+      }
+    }
+    Cache.del(placeholder, 'foo')
+    expect(placeholder.redis.del).toBeCalledWith('foo')
+  })
+})
+
+describe('cache.getFromStore', () => {
+  it('should return local value if found', () => {
+    const localGet = jest.fn(() => 'localValue')
+    const redisGet = jest.fn()
+
+    const cache = {}
+    _.set(cache, 'local.get', localGet)
+    _.set(cache, 'redis.get', redisGet)
+
+    return Cache.getFromStore(cache, 'key').then(result => {
+      expect(result).toEqual('localValue')
+      expect(localGet).toBeCalledWith('key')
+      expect(redisGet).not.toBeCalled()
+    })
+  })
+
+  it('should fetch from redis if local not found, only store locally if value found', () => {
+    const localGet = jest.fn(() => undefined)
+    const localSet = jest.fn(() => undefined)
+    const redisGet = jest.fn(() => Promise.resolve('remoteValue'))
+
+    const cache = {}
+    _.set(cache, 'local.get', localGet)
+    _.set(cache, 'local.set', localSet)
+    _.set(cache, 'redis.get', redisGet)
+    _.set(cache, 'settings.localTTL', 1000)
+
+    return Cache.getFromStore(cache, 'key').then(result => {
+      expect(result).toEqual('remoteValue')
+      expect(localGet).toBeCalledWith('key')
+      expect(redisGet).toBeCalledWith('key')
+      expect(localSet).toBeCalledWith('key', 'remoteValue', 1000)
+    })
+  })
+
+  it('should fetch from redis if local not found, skip local store if not found', () => {
+    const localGet = jest.fn(() => undefined)
+    const localSet = jest.fn(() => undefined)
+    const redisGet = jest.fn(() => Promise.resolve(undefined))
+
+    const cache = {}
+    _.set(cache, 'local.get', localGet)
+    _.set(cache, 'local.set', localSet)
+    _.set(cache, 'redis.get', redisGet)
+    _.set(cache, 'settings.localTTL', 1000)
+
+    return Cache.getFromStore(cache, 'key').then(result => {
+      expect(result).toEqual(undefined)
+      expect(localGet).toBeCalledWith('key')
+      expect(redisGet).toBeCalledWith('key')
+      expect(localSet).not.toBeCalled()
+    })
+  })
+})
+
+describe('create', () => {
+  it('should create a cache client', () => {
+    const cache = require('./cache')
+    return cache.create().then(result => {
+      expect(result.set).toBeInstanceOf(Function)
+      expect(result.get).toBeInstanceOf(Function)
+      expect(result.del).toBeInstanceOf(Function)
+    })
+  })
+
+  describe('cache.get', () => {
+    it('should get key from store if key exists in redis store', () => {
+      const getFromStore = jest
+        .spyOn(Cache, 'getFromStore')
+        .mockReturnValue(true)
+
+      const del = jest.fn()
+
+      const cache = {}
+      _.set(cache, 'redis.exists', () => Promise.resolve(true))
+      _.set(cache, 'local.del', del)
+      return Cache.get(cache, 'key').then(() => {
+        expect(getFromStore).toBeCalledWith(cache, 'key')
+        expect(del).not.toBeCalled()
+      })
+    })
+    it('should attempt deleting key from local if key does not exists in redis anymore', () => {
+      const getFromStore = jest
+        .spyOn(Cache, 'getFromStore')
+        .mockReturnValue(true)
+
+      const del = jest.fn()
+
+      const cache = {}
+      _.set(cache, 'redis.exists', () => Promise.resolve(false))
+      _.set(cache, 'local.del', del)
+      return Cache.get(cache, 'key').then(() => {
+        expect(getFromStore).not.toBeCalled()
+        expect(del).toBeCalledWith('key')
+      })
+    })
+  })
+
+  describe('cache.del', () => {
+    it('should delete key', () => {
+      return Cache.create().then(result => {
+        result.redis.del = jest.fn()
+        result.del('foo')
+        expect(result.redis.del).toBeCalledWith('foo')
+      })
+    })
+  })
+})

--- a/packages/data-point-cache/lib/redis-client.js
+++ b/packages/data-point-cache/lib/redis-client.js
@@ -49,6 +49,7 @@ function create (options = {}) {
     redis: null,
     set: null,
     get: null,
+    del: null,
     exists: null,
     options
   }
@@ -65,6 +66,7 @@ function create (options = {}) {
 function bootstrap (cache) {
   cache.set = set.bind(null, cache)
   cache.get = get.bind(null, cache)
+  cache.del = del.bind(null, cache)
   cache.exists = exists.bind(null, cache)
   return cache
 }
@@ -115,6 +117,14 @@ function exists (cache, key) {
     .then(res => res[0][1] === 1)
 }
 
+function del (cache, key) {
+  const redis = cache.redis
+  return redis
+    .pipeline()
+    .del(key)
+    .exec()
+}
+
 module.exports = {
   redisDecorator,
   getFromRedisResult,
@@ -124,6 +134,7 @@ module.exports = {
   bootstrap,
   set,
   get,
+  del,
   exists,
   encode,
   decode

--- a/packages/data-point-cache/lib/redis-client.test.js
+++ b/packages/data-point-cache/lib/redis-client.test.js
@@ -65,6 +65,7 @@ describe('create', () => {
       expect(typeof redisClient.redis.set === 'function').toBeTruthy()
       expect(typeof redisClient.get === 'function').toBeTruthy()
       expect(typeof redisClient.set === 'function').toBeTruthy()
+      expect(typeof redisClient.del === 'function').toBeTruthy()
       expect(typeof redisClient.exists === 'function').toBeTruthy()
     })
   })
@@ -180,6 +181,29 @@ describe('get/set/exists', () => {
       return redisClient.exists('invalid').then(value => {
         expect(value).toEqual(false)
       })
+    })
+  })
+
+  test('It should delete a key', () => {
+    return RedisClient.create().then(redisClient => {
+      const redis = redisClient.redis
+
+      return redis
+        .pipeline()
+        .set('toBeRemoved', 'foo')
+        .exec()
+        .then(() => {
+          return redisClient.del('toBeRemoved')
+        })
+        .then(() => {
+          return redis
+            .pipeline()
+            .get('toBeRemoved')
+            .exec()
+        })
+        .then(result => {
+          expect(result).toEqual([[null, null]])
+        })
     })
   })
 })


### PR DESCRIPTION
local and redis delete and adds missing tests

re #303

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: adds delete to redis and local cache store api

<!-- Why are these changes necessary? -->
**Why**: this is in preparation for revalidation PR (coming after this) that relies on being able to delete a key from the store to invalidate it

<!-- How were these changes implemented? -->
**How**: adds the del method to both stores plus missing tests

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
