### PR TITLE
feat(data-point-service): support revalidation concurrency

### DIFF
--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -98,7 +98,8 @@ To configure an entity's cache settings you must set cache configuration through
   params: {
     cache: {
       ttl: String|Number,
-      staleWhileRevalidate: String|Number
+      staleWhileRevalidate: String|Number,
+      revalidateTimeout: String|Number
     }
   }
 }
@@ -134,6 +135,10 @@ DataPointService.create({
 
 ### cache.staleWhileRevalidate
 
+```js
+staleWhileRevalidate: String|Number|Boolean
+```
+
 `staleWhileRevalidate = delta-seconds`
 
 `staleWhileRevalidate` value is expected to be written as a string following the format supported by [ms](https://www.npmjs.com/package/ms). Alternately it may also be set to `true`, which tells the entity to use double the time of the value of its `ttl`.
@@ -160,6 +165,24 @@ DataPointService.create({
   }
 })
 ```
+
+### cache.revalidateTimeout
+
+Defaults to `'5s'` (seconds).
+
+`revalidateTimeout` is the time a revalidation process has before it times-out, the value is expected to be written as a string (eg. `'20m'`) following the format supported by [ms](https://www.npmjs.com/package/ms). When revalidation starts a **revalidation flag** is set which blocks revalidation duplicates from happening, once the revalidation times-out the revalidation flag will be removed and the **key** will be unblocked for being revalidated again. If omitted it defaults to 5 seconds. 
+
+This value is only used when `staleWhileRevalidate` is also set.
+
+## Revalidation and concurrency
+
+When a an entity is requested for the first time it will be considered a _cold lookup_, once the entity is resolved a cache entry will be saved on **redis**. For the key's life set by the entity's `ttl` (and `staleWhileRevalidate`) the entity will return the value (considered **stale**) from the **redis** store. Once a new request is made for the key and it's `ttl` has expired a revalidation will be triggered _on the background_; when a revalidation starts a revalidation **flag** will be added to prevent new calls of duplicating the revalidation process. 
+
+Revalidation flags are saved **locally** (in memory - they get cleared once their timeout expires) and also added to the redis store to be accessed by multiple node instances sharing the same keys. The **local** flag is to prevent duplicate revalidation by a single instance, because it is in memory it is an instant lookup; the **remote** flag (redis) is to prevent multiple instances of attempting to revalidate the same request.  
+
+In the case the revalidation fails the flag will be removed to allow a new revalidation to be triggered.
+
+It is important to know that once the `staleWhileRevalidate` delta has also expired a background revalidation will no longer be triggered and cold lookup will be triggered instead. For this reason it is important to carefully set the cache settings to have a solid caching strategy.
 
 ## <a name="contributing">Contributing</a>
 

--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -172,6 +172,7 @@ DataPointService.create({
 revalidateTimeout: String|Number
 ```
 
+*defaults to*: `5s`
 
 `revalidateTimeout` is the time a revalidation process has before it times-out, the value is expected to be written as a string (eg. `'20m'`) following the format supported by [ms](https://www.npmjs.com/package/ms). When revalidation starts a **revalidation flag** is set which blocks revalidation duplicates from happening. Once the revalidation times-out the revalidation flag will be removed and the **key** will be unblocked for being revalidated again. If omitted it defaults to 5 seconds. 
 

--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -168,7 +168,10 @@ DataPointService.create({
 
 ### cache.revalidateTimeout
 
-Defaults to `'5s'` (seconds).
+```js
+staleWhileRevalidate: String|Number
+```
+
 
 `revalidateTimeout` is the time a revalidation process has before it times-out, the value is expected to be written as a string (eg. `'20m'`) following the format supported by [ms](https://www.npmjs.com/package/ms). When revalidation starts a **revalidation flag** is set which blocks revalidation duplicates from happening, once the revalidation times-out the revalidation flag will be removed and the **key** will be unblocked for being revalidated again. If omitted it defaults to 5 seconds. 
 

--- a/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
@@ -1,43 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`catchRevalidateError should handle revalidation error 1`] = `
+Array [
+  Array [
+    "Could not revalidate entityId: %s with cache key: %s
+",
+    "entityId",
+    "entryKey",
+    [Error: test],
+  ],
+]
+`;
+
+exports[`catchRevalidateError should log errors when clearing flags fail 1`] = `
+Array [
+  Array [
+    "Could not revalidate entityId: %s with cache key: %s
+",
+    "entityId",
+    "entryKey",
+    [Error: test],
+  ],
+  Array [
+    "Error while clearing revalidation flags for cache key: %s",
+    "entryKey",
+    [Error: revalidation],
+  ],
+]
+`;
+
 exports[`revalidateEntry should log at debug level start and success 1`] = `
 Array [
   Array [
     "Revalidating entityId: %s with cache key: %s",
     "model:Foo",
-    "key",
+    "entryKey",
   ],
+]
+`;
+
+exports[`revalidateSuccess should remove local flag and add debug log 1`] = `
+Array [
   Array [
     "Succesful revalidation entityId: %s with cache key: %s",
-    "model:Foo",
-    "key",
+    "entityId",
+    "entryKey",
   ],
 ]
 `;
 
-exports[`revalidateEntry should log error level when error occurs 1`] = `
+exports[`updateSWREntry should add stale entry 1`] = `
 Array [
   Array [
-    "Could not revalidate entityId: %s with cache key: %s
-",
-    "model:Foo",
-    "key",
-    [Error: TestError],
-  ],
-]
-`;
-
-exports[`revalidateEntry should set cache 1`] = `
-Array [
-  Array [
-    "key:swr.stale",
-    undefined,
-    400,
-  ],
-  Array [
-    "key:swr.control",
-    "SWR-CONTROL-STALE",
-    200,
+    "Updating cache key: %s with new stale value",
+    "entryKey",
   ],
 ]
 `;

--- a/packages/data-point-service/lib/__snapshots__/revalidation-store.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/revalidation-store.test.js.snap
@@ -10,10 +10,10 @@ Array [
 
 exports[`create implementation should clear entries 1`] = `
 Map {
-  "t1" => Array [
-    1000,
-    100,
-  ],
+  "t1" => Object {
+    "created": 1000,
+    "ttl": 100,
+  },
 }
 `;
 

--- a/packages/data-point-service/lib/__snapshots__/revalidation-store.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/revalidation-store.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`clear should remove expired keys 1`] = `
+Array [
+  Array [
+    "local revalidation flags that timed out: t2",
+  ],
+]
+`;
+
+exports[`create implementation should clear entries 1`] = `
+Map {
+  "t1" => Array [
+    1000,
+    100,
+  ],
+}
+`;
+
+exports[`create should create a new store that matches snapshot api 1`] = `
+Object {
+  "add": [Function],
+  "clear": [Function],
+  "exists": [Function],
+  "remove": [Function],
+  "store": Map {},
+}
+`;

--- a/packages/data-point-service/lib/__snapshots__/stale-while-revalidate.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/stale-while-revalidate.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create should create stale while revalidate controller 1`] = `
+Object {
+  "addEntry": [Function],
+  "addRevalidationFlags": [Function],
+  "clearAllRevalidationFlags": [Function],
+  "getEntry": [Function],
+  "getRevalidationState": [Function],
+  "invalidateLocalFlags": [Function],
+  "removeLocalRevalidationFlag": [Function],
+}
+`;

--- a/packages/data-point-service/lib/cache-middleware.test.js
+++ b/packages/data-point-service/lib/cache-middleware.test.js
@@ -1,19 +1,43 @@
 /* eslint-env jest */
 
+const Promise = require('bluebird')
+
 const mockDebug = jest.fn()
 jest.mock('debug', () => {
   return () => mockDebug
 })
 
-const util = require('util')
-const ms = require('ms')
-util.deprecate = jest.fn(fn => fn)
+jest.mock('./stale-while-revalidate')
+jest.mock('./entity-cache-params')
+jest.mock('./redis-controller')
+
+const StaleWhileRevalidate = require('./stale-while-revalidate')
+const EntityCacheParams = require('./entity-cache-params')
+const RedisController = require('./redis-controller')
 
 const CacheMiddleware = require('./cache-middleware')
 
+const _ = require('lodash')
+
+const createNext = (done, tests) =>
+  jest.fn(() => {
+    try {
+      tests()
+    } catch (error) {
+      return done(error)
+    }
+    done()
+  })
+
 function createContext () {
   const ctx = {
-    locals: {},
+    locals: {
+      req: {
+        app: {
+          locals: {}
+        }
+      }
+    },
     context: {
       params: {},
       id: 'model:Foo'
@@ -24,28 +48,10 @@ function createContext () {
   return ctx
 }
 
-function createMocks () {
-  const resolveFromAccumulator = jest.fn(() => Promise.resolve('output'))
-  const set = jest.fn(() => Promise.resolve(true))
-  const get = jest.fn(() => Promise.resolve(true))
-  const service = {
-    dataPoint: {
-      resolveFromAccumulator
-    },
-    cache: {
-      set,
-      get
-    }
-  }
-  const ctx = createContext()
-  return {
-    resolveFromAccumulator,
-    set,
-    get,
-    service,
-    ctx
-  }
-}
+beforeEach(() => {
+  jest.resetModules()
+  jest.resetAllMocks()
+})
 
 describe('genrateKey', () => {
   it('should generate default id', () => {
@@ -66,113 +72,245 @@ describe('genrateKey', () => {
   })
 })
 
-describe('setStaleWhileRevalidateEntry', () => {
-  it('should store stale entry and SWR control entry', () => {
-    const set = jest.fn(() => Promise.resolve(true))
-    const service = {
-      cache: {
-        set
-      }
-    }
+describe('revalidateSuccess', () => {
+  it('should remove local flag and add debug log', () => {
+    const mockRemoveLocalRevalidationFlag = jest.fn()
+    const service = _.set(
+      {},
+      'staleWhileRevalidate.removeLocalRevalidationFlag',
+      mockRemoveLocalRevalidationFlag
+    )
+    CacheMiddleware.revalidateSuccess(service, 'entityId', 'entryKey')()
+    expect(mockRemoveLocalRevalidationFlag).toBeCalledWith('entryKey')
+    expect(mockDebug.mock.calls).toMatchSnapshot()
+  })
+})
 
-    const cache = {
-      ttl: 200,
-      staleWhileRevalidateTtl: 400
-    }
+describe('updateSWREntry', () => {
+  it('should add stale entry', () => {
+    const mockAddEntry = jest.fn()
+    const service = _.set({}, 'staleWhileRevalidate.addEntry', mockAddEntry)
+    const acc = _.set({}, 'value', 'value')
+    CacheMiddleware.updateSWREntry(service, 'entryKey', 'cache')(acc)
+    expect(mockAddEntry).toBeCalledWith('entryKey', 'value', 'cache')
+    expect(mockDebug.mock.calls).toMatchSnapshot()
+  })
+})
 
-    return CacheMiddleware.setStaleWhileRevalidateEntry(
+describe('catchRevalidateError', () => {
+  it('should handle revalidation error', () => {
+    const mockClearAllRevalidationFlags = jest.fn(() => Promise.resolve(true))
+    const spyConsoleError = jest.spyOn(console, 'error').mockImplementation()
+    const service = _.set(
+      {},
+      'staleWhileRevalidate.clearAllRevalidationFlags',
+      mockClearAllRevalidationFlags
+    )
+
+    const error = new Error('test')
+
+    return CacheMiddleware.catchRevalidateError(
       service,
-      'key',
-      'value',
-      cache
-    ).then(() => {
-      expect(set.mock.calls[0]).toEqual(['key:swr.stale', 'value', 400])
-      expect(set.mock.calls[1]).toEqual([
-        'key:swr.control',
-        'SWR-CONTROL-STALE',
-        200
-      ])
+      'entityId',
+      'entryKey'
+    )(error).then(() => {
+      expect(mockClearAllRevalidationFlags).toBeCalledWith('entryKey')
+      expect(spyConsoleError.mock.calls).toMatchSnapshot()
+    })
+  })
+
+  it('should log errors when clearing flags fail', () => {
+    const mockClearAllRevalidationFlags = jest.fn(() =>
+      Promise.reject(new Error('revalidation'))
+    )
+    const spyConsoleError = jest.spyOn(console, 'error').mockImplementation()
+    const service = _.set(
+      {},
+      'staleWhileRevalidate.clearAllRevalidationFlags',
+      mockClearAllRevalidationFlags
+    )
+
+    const error = new Error('test')
+
+    return CacheMiddleware.catchRevalidateError(
+      service,
+      'entityId',
+      'entryKey'
+    )(error).then(() => {
+      expect(mockClearAllRevalidationFlags).toBeCalledWith('entryKey')
+      expect(spyConsoleError.mock.calls).toMatchSnapshot()
     })
   })
 })
 
+describe('shouldTriggerRevalidate', () => {
+  it('should return false if staleEntry is not truthly', () => {
+    expect(CacheMiddleware.shouldTriggerRevalidate(undefined)).toEqual(false)
+  })
+  it('should return false if revalidationState.hasExternalEntryExpired is not true', () => {
+    const revalidationState = {
+      hasExternalEntryExpired: false
+    }
+    expect(
+      CacheMiddleware.shouldTriggerRevalidate(true, revalidationState)
+    ).toEqual(false)
+  })
+
+  it('should return false if revalidationState.isRevalidatingLocally() is true', () => {
+    const revalidationState = {
+      hasExternalEntryExpired: true,
+      isRevalidatingLocally: () => true
+    }
+    expect(
+      CacheMiddleware.shouldTriggerRevalidate(true, revalidationState)
+    ).toEqual(false)
+  })
+
+  it('should return true if revalidationState.isRevalidatingLocally() is true', () => {
+    const revalidationState = {
+      hasExternalEntryExpired: true,
+      isRevalidatingLocally: () => false
+    }
+    expect(
+      CacheMiddleware.shouldTriggerRevalidate(true, revalidationState)
+    ).toEqual(true)
+  })
+})
+
 describe('revalidateEntry', () => {
-  let logError
   const cache = {
     ttl: 200,
-    staleWhileRevalidateTtl: 400
+    staleWhileRevalidateTtl: 400,
+    revalidateTimeout: 5000
   }
 
-  beforeEach(() => {
-    logError = console.error
-    mockDebug.mockReset()
-  })
+  function createMocks () {
+    const mocks = {}
 
-  afterEach(() => {
-    console.error = logError
-  })
+    mocks.updateSWREntry = jest
+      .spyOn(CacheMiddleware, 'updateSWREntry')
+      .mockImplementation(() => () => Promise.resolve('updateSWREntry'))
+    mocks.revalidateSuccess = jest
+      .spyOn(CacheMiddleware, 'revalidateSuccess')
+      .mockImplementation(() => () => Promise.resolve('revalidateSuccess'))
+    mocks.catchRevalidateError = jest
+      .spyOn(CacheMiddleware, 'catchRevalidateError')
+      .mockImplementation(() => () => Promise.resolve('catchRevalidateError'))
+
+    mocks.addRevalidationFlags = jest.fn(() => () => Promise.resolve('flags'))
+    mocks.service = {}
+    _.set(
+      mocks.service,
+      'staleWhileRevalidate.addRevalidationFlags',
+      mocks.addRevalidationFlags
+    )
+
+    mocks.resolveFromAccumulator = jest.fn(() => Promise.resolve('resolved'))
+    _.set(
+      mocks.service,
+      'dataPoint.resolveFromAccumulator',
+      mocks.resolveFromAccumulator
+    )
+
+    return mocks
+  }
 
   it('should log at debug level start and success', () => {
     const mocks = createMocks()
+    const ctx = createContext()
     return CacheMiddleware.revalidateEntry(
       mocks.service,
-      'key',
+      'entryKey',
       cache,
-      mocks.ctx
+      ctx
     ).then(() => {
       expect(mockDebug.mock.calls).toMatchSnapshot()
     })
   })
 
-  it('should log error level when error occurs', () => {
+  it('should call error handler when error thrown', () => {
     const mocks = createMocks()
-    console.error = jest.fn()
-    mocks.service.dataPoint.resolveFromAccumulator = () =>
-      Promise.reject(new Error('TestError'))
+    const error = new Error('resolved')
+    mocks.resolveFromAccumulator.mockImplementation(() => Promise.reject(error))
+
+    const errorHandler = jest.fn(() => true)
+    mocks.catchRevalidateError.mockImplementation(() => errorHandler)
+
+    const ctx = createContext()
 
     return CacheMiddleware.revalidateEntry(
       mocks.service,
-      'key',
+      'entryKey',
       cache,
-      mocks.ctx
+      ctx
     ).then(() => {
-      expect(console.error.mock.calls).toMatchSnapshot()
+      expect(mocks.catchRevalidateError).toBeCalledWith(
+        mocks.service,
+        'model:Foo',
+        'entryKey'
+      )
+      expect(errorHandler).toBeCalledWith(error)
     })
   })
 
   it('should call dataPoint.resolveFromAccumulator with flagged context object', () => {
     const mocks = createMocks()
+    const ctx = createContext()
     return CacheMiddleware.revalidateEntry(
       mocks.service,
-      'key',
+      'entryKey',
       cache,
-      mocks.ctx
+      ctx
     ).then(() => {
       // original context should not be mutated
-      expect(mocks.ctx).not.toHaveProperty('locals.revalidatingCache')
+      expect(ctx).not.toHaveProperty('locals.revalidatingCache')
+
+      // inpsect arguments passed to dataPoint.resolveFromAccumulator
       const resolveFromAccumulatorArgs =
         mocks.resolveFromAccumulator.mock.calls[0]
+
       expect(resolveFromAccumulatorArgs[0]).toEqual('model:Foo')
       expect(resolveFromAccumulatorArgs[1]).toHaveProperty(
         'locals.revalidatingCache',
         {
-          entryKey: 'key',
+          entryKey: 'entryKey',
           entityId: 'model:Foo'
         }
       )
     })
   })
 
-  it('should set cache', () => {
+  it('should call updateSWREntry', () => {
     const mocks = createMocks()
+    const ctx = createContext()
     return CacheMiddleware.revalidateEntry(
       mocks.service,
-      'key',
+      'entryKey',
       cache,
-      mocks.ctx
+      ctx
     ).then(() => {
-      expect(mocks.resolveFromAccumulator).toBeCalled()
-      expect(mocks.set.mock.calls).toMatchSnapshot()
+      expect(mocks.updateSWREntry).toBeCalledWith(
+        mocks.service,
+        'entryKey',
+        cache
+      )
+    })
+  })
+
+  it('should call revalidateSuccess', () => {
+    const mocks = createMocks()
+    const ctx = createContext()
+    return CacheMiddleware.revalidateEntry(
+      mocks.service,
+      'entryKey',
+      cache,
+      ctx
+    ).then(() => {
+      expect(mocks.revalidateSuccess).toBeCalledWith(
+        mocks.service,
+        'model:Foo',
+        'entryKey'
+      )
     })
   })
 })
@@ -200,321 +338,413 @@ describe('isRevalidatingCacheKey', () => {
 })
 
 describe('resolveStaleWhileRevalidateEntry', () => {
-  let logDebug
-  let logError
   const cache = {
     ttl: 200,
     staleWhileRevalidateTtl: 400
   }
 
-  beforeEach(() => {
-    logError = console.error
-    // to hide when not testing it got called
-    console.debug = () => true
-  })
-  afterEach(() => {
-    console.debug = logDebug
-    console.error = logError
+  function createMocks () {
+    const mocks = {}
+    mocks.isRevalidatingCacheKey = jest
+      .spyOn(CacheMiddleware, 'isRevalidatingCacheKey')
+      .mockReturnValue(false)
+
+    mocks.shouldTriggerRevalidate = jest
+      .spyOn(CacheMiddleware, 'shouldTriggerRevalidate')
+      .mockReturnValue(false)
+
+    mocks.revalidateEntry = jest
+      .spyOn(CacheMiddleware, 'revalidateEntry')
+      .mockReturnValue(false)
+
+    const service = {}
+
+    _.set(service, 'staleWhileRevalidate.invalidateLocalFlags', jest.fn())
+    _.set(
+      service,
+      'staleWhileRevalidate.getRevalidationState',
+      jest.fn(() => 'revalidationState')
+    )
+    _.set(service, 'staleWhileRevalidate.getEntry', jest.fn(() => 'staleEntry'))
+
+    mocks.service = service
+    mocks.ctx = createContext()
+    mocks.setTimeout = jest.spyOn(global, 'setTimeout').mockReturnValue(true)
+
+    return mocks
+  }
+
+  afterAll(() => {
+    setTimeout.mockRestore()
   })
 
-  it('should exit if revalidation flag is set', () => {
+  it('should exit with undefined if isRevalidatingCacheKey is true', () => {
     const mocks = createMocks()
-    mocks.ctx.locals.revalidatingCache = {
-      entryKey: 'key'
-    }
+    // by default mock.isRevalidatingCacheKey is set to return false
+    mocks.isRevalidatingCacheKey.mockReturnValue(true)
+
     const result = CacheMiddleware.resolveStaleWhileRevalidateEntry(
       mocks.service,
-      'key',
-      200,
+      'entryKey',
+      cache,
       mocks.ctx
     )
+    expect(mocks.isRevalidatingCacheKey).toBeCalledWith(mocks.ctx, 'entryKey')
     expect(result).toBeUndefined()
   })
 
-  it('should return undefined if revalidation flag is set', () => {
+  it('should create and attach staleWhileRevalidate instance to service object', () => {
     const mocks = createMocks()
-    mocks.ctx.locals.revalidatingCache = {
-      entryKey: 'key'
-    }
-    const result = CacheMiddleware.resolveStaleWhileRevalidateEntry(
-      mocks.service,
-      'key',
-      cache,
-      mocks.ctx
-    )
-    expect(result).toBeUndefined()
-  })
 
-  it('should return stale entry', () => {
-    const mocks = createMocks()
-    mocks.service.cache.get = jest.fn(key => {
-      return Promise.resolve().then(() => {
-        if (key === 'key:swr.stale') {
-          return 'STALE'
-        }
-        // this forces getSWRControlEntry to return true
-        if (key === 'key:swr.control') {
-          return 'SWR-CONTROL'
-        }
-      })
-    })
-    const result = CacheMiddleware.resolveStaleWhileRevalidateEntry(
+    // this needs to be done since the createMocks creates one for us
+    const staleWhileRevalidate = mocks.service.staleWhileRevalidate
+    delete mocks.service.staleWhileRevalidate
+
+    StaleWhileRevalidate.create.mockImplementation(() => staleWhileRevalidate)
+
+    return CacheMiddleware.resolveStaleWhileRevalidateEntry(
       mocks.service,
-      'key',
+      'entryKey',
       cache,
       mocks.ctx
-    )
-    return result.then(value => {
-      expect(value).toEqual('STALE')
+    ).then(() => {
+      expect(StaleWhileRevalidate.create).toBeCalledWith(mocks.service)
+      expect(mocks.service).toHaveProperty(
+        'staleWhileRevalidate',
+        staleWhileRevalidate
+      )
     })
   })
 
-  it('should not call revalidateEntry if stale is not there', () => {
+  it('should call staleWhileRevalidate.create only once', () => {
     const mocks = createMocks()
-    const spyRevalidateEntry = jest.spyOn(CacheMiddleware, 'revalidateEntry')
-    mocks.service.cache.get = jest.fn(key => {
-      return Promise.resolve().then(() => {
-        if (key === 'key:swr.stale') {
-          return 'STALE'
-        }
-        // this forces getSWRControlEntry to return true, simulating that key's ttl
-        // has not expired
-        if (key === 'key:swr.control') {
-          return 'SWR-CONTROL'
-        }
-      })
-    })
 
-    const result = CacheMiddleware.resolveStaleWhileRevalidateEntry(
-      mocks.service,
-      'key',
-      cache,
-      mocks.ctx
-    )
-    return result.then(value => {
-      expect(spyRevalidateEntry).not.toBeCalled()
-      expect(value).toEqual('STALE')
-      spyRevalidateEntry.mockRestore()
-    })
-  })
+    // this needs to be done since the createMocks creates one for us
+    const staleWhileRevalidate = mocks.service.staleWhileRevalidate
+    delete mocks.service.staleWhileRevalidate
 
-  it('should call revalidateEntry if stale is there and our control has expired', () => {
-    const mocks = createMocks()
-    const spyRevalidateEntry = jest.spyOn(CacheMiddleware, 'revalidateEntry')
-    spyRevalidateEntry.mockImplementation(() => true)
-    mocks.service.cache.get = jest.fn(key => {
-      return Promise.resolve().then(() => {
-        if (key === 'key:swr.stale') {
-          return 'STALE'
-        }
-        // this forces getSWRControlEntry to return false, simulating that key's ttl
-        // has now expired
-        if (key === 'key:swr.control') {
-          return undefined
-        }
-      })
-    })
-    const result = CacheMiddleware.resolveStaleWhileRevalidateEntry(
-      mocks.service,
-      'key',
-      cache,
-      mocks.ctx
-    )
-    return result.then(value => {
-      expect(spyRevalidateEntry).toBeCalledWith(
+    StaleWhileRevalidate.create.mockImplementation(() => staleWhileRevalidate)
+
+    const results = [
+      CacheMiddleware.resolveStaleWhileRevalidateEntry(
         mocks.service,
-        'key',
+        'entryKey',
+        cache,
+        mocks.ctx
+      ),
+      CacheMiddleware.resolveStaleWhileRevalidateEntry(
+        mocks.service,
+        'entryKey',
         cache,
         mocks.ctx
       )
-      expect(value).toEqual('STALE')
-      spyRevalidateEntry.mockReset()
-      spyRevalidateEntry.mockRestore()
+    ]
+    return Promise.all(results).then(() => {
+      expect(StaleWhileRevalidate.create).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should call staleWhileRevalidate.invalidateLocalFlags on a new tick', () => {
+    const mocks = createMocks()
+    return CacheMiddleware.resolveStaleWhileRevalidateEntry(
+      mocks.service,
+      'entryKey',
+      cache,
+      mocks.ctx
+    ).then(() => {
+      expect(mocks.setTimeout).toHaveBeenCalledWith(
+        mocks.service.staleWhileRevalidate.invalidateLocalFlags,
+        0
+      )
+    })
+  })
+
+  it('should return stale entry value and not call revalidateEntry if shouldTriggerRevalidate returns false', () => {
+    const mocks = createMocks()
+
+    mocks.shouldTriggerRevalidate.mockReturnValue(false)
+    return CacheMiddleware.resolveStaleWhileRevalidateEntry(
+      mocks.service,
+      'entryKey',
+      cache,
+      mocks.ctx
+    ).then(result => {
+      expect(mocks.shouldTriggerRevalidate).toHaveBeenCalledWith(
+        'staleEntry',
+        'revalidationState'
+      )
+      expect(result).toEqual('staleEntry')
+    })
+  })
+
+  it('should return stale entry value and call revalidateEntry if shouldTriggerRevalidate returns true', () => {
+    const mocks = createMocks()
+
+    mocks.shouldTriggerRevalidate.mockReturnValue(true)
+    return CacheMiddleware.resolveStaleWhileRevalidateEntry(
+      mocks.service,
+      'entryKey',
+      cache,
+      mocks.ctx
+    ).then(result => {
+      expect(mocks.revalidateEntry).toHaveBeenCalledWith(
+        mocks.service,
+        'entryKey',
+        cache,
+        mocks.ctx
+      )
+      expect(result).toEqual('staleEntry')
+    })
+  })
+})
+
+describe('setStaleWhileRevalidateEntry', () => {
+  it('should add entry to staleWhileRevalidate controller', () => {
+    const mockAddEntry = jest.fn(() => Promise.resolve(true))
+    jest.spyOn(CacheMiddleware, 'resolveStaleWhileRevalidate').mockReturnValue({
+      addEntry: mockAddEntry
+    })
+    const service = {}
+    return CacheMiddleware.setStaleWhileRevalidateEntry(
+      service,
+      'entryKey',
+      'value',
+      'cache'
+    ).then(() => {
+      expect(mockAddEntry).toBeCalledWith('entryKey', 'value', 'cache')
     })
   })
 })
 
 describe('before', () => {
-  it('should call next if no  ttl', () => {
-    const mocks = createMocks()
-    const next = jest.fn()
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
-    expect(next).toBeCalledWith() // with no arguments
-  })
-
-  it('should call next if ttl exists but resetCache is true', () => {
-    const mocks = createMocks()
-    const next = jest.fn()
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.locals.resetCache = true
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
-    expect(next).toBeCalledWith() // with no arguments
-  })
-
-  it('should attempt to resolve staleWhileRevalidate if ttl exists and staleWhileRevalidate is set', done => {
-    const mocks = createMocks()
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.context.params.staleWhileRevalidate = '10m'
-
-    const spyResolveStaleWhileRevalidateEntry = jest.spyOn(
-      CacheMiddleware,
-      'resolveStaleWhileRevalidateEntry'
-    )
-    spyResolveStaleWhileRevalidateEntry.mockImplementation(() => true)
-
-    const cache = {
+  function createMocks () {
+    const mocks = {}
+    mocks.ctx = createContext()
+    mocks.ctx.resolve = jest.fn()
+    mocks.service = {}
+    mocks.cache = {
       ttl: '20m',
-      cacheKey: undefined,
-      useStaleWhileRevalidate: true,
-      staleWhileRevalidateTtl: ms('20m') + ms('10m')
+      cacheKey: () => true,
+      useStaleWhileRevalidate: true
     }
 
-    const next = () => {
-      expect(spyResolveStaleWhileRevalidateEntry).toHaveBeenCalledWith(
+    mocks.next = jest.fn()
+
+    mocks.getCacheParams = jest
+      .spyOn(EntityCacheParams, 'getCacheParams')
+      .mockReturnValue(mocks.cache)
+
+    mocks.generateKey = jest
+      .spyOn(CacheMiddleware, 'generateKey')
+      .mockReturnValue('mockCacheKey')
+
+    mocks.resolveStaleWhileRevalidateEntry = jest
+      .spyOn(CacheMiddleware, 'resolveStaleWhileRevalidateEntry')
+      .mockReturnValue('staleResult')
+
+    mocks.getEntry = jest
+      .spyOn(RedisController, 'getEntry')
+      .mockReturnValue('noTTLEntry')
+
+    return mocks
+  }
+
+  describe('exit to avoid cache process', () => {
+    it('should call next and return false if no ttl', () => {
+      const mocks = createMocks()
+      mocks.cache.ttl = undefined
+      const result = CacheMiddleware.before(
         mocks.service,
-        'entity:model:Foo',
-        cache,
+        mocks.ctx,
+        mocks.next
+      )
+      expect(result).toEqual(false)
+      expect(mocks.next).toBeCalledWith()
+    })
+    it('should call next and return false if resetCache is true', () => {
+      const mocks = createMocks()
+      mocks.ctx.locals.resetCache = true
+      const result = CacheMiddleware.before(
+        mocks.service,
+        mocks.ctx,
+        mocks.next
+      )
+      expect(result).toEqual(false)
+      expect(mocks.next).toBeCalledWith()
+    })
+  })
+
+  it('should resolve to stale value if cache.useStaleWhileRevalidate is true and stale value exists', done => {
+    const mocks = createMocks()
+
+    const next = createNext(done, () => {
+      expect(mocks.ctx.resolve).toBeCalledWith('staleResult')
+      expect(mocks.resolveStaleWhileRevalidateEntry).toBeCalledWith(
+        mocks.service,
+        'mockCacheKey',
+        mocks.cache,
         mocks.ctx
       )
-      done()
-    }
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
-  })
-
-  it('should resolve as normal cache key when staleWhileRevalidate is falsy', done => {
-    const mocks = createMocks()
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.context.params.staleWhileRevalidate = undefined
-    mocks.service.cache.get = jest.fn()
-
-    const next = jest.fn(() => {
-      expect(mocks.service.cache.get).toHaveBeenCalledWith('entity:model:Foo')
-      expect(next).toBeCalled()
-      done()
+      expect(mocks.getEntry).not.toBeCalled()
     })
 
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    const result = CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    expect(result).toEqual(true)
   })
 
-  it('should call ctx.resolve if value is not undefined', done => {
+  it('should resolve to basic redis entry if cache.useStaleWhileRevalidate is false and value exists', done => {
     const mocks = createMocks()
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.resolve = jest.fn()
-    mocks.ctx.context.params.staleWhileRevalidate = undefined
-    mocks.service.cache.get = () => 'value'
 
-    const next = jest.fn(() => {
-      expect(mocks.ctx.resolve).toBeCalledWith('value')
-      expect(next).toBeCalled()
-      done()
+    mocks.cache.useStaleWhileRevalidate = false
+
+    const next = createNext(done, () => {
+      expect(mocks.ctx.resolve).toBeCalledWith('noTTLEntry')
+      expect(mocks.resolveStaleWhileRevalidateEntry).not.toBeCalled()
+      expect(mocks.getEntry).toBeCalledWith(mocks.service, 'mockCacheKey')
     })
 
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    const result = CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    expect(result).toEqual(true)
   })
-  it('should not call ctx.resolve if value is undefined', done => {
-    const mocks = createMocks()
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.resolve = jest.fn()
-    mocks.ctx.context.params.staleWhileRevalidate = undefined
-    mocks.service.cache.get = () => undefined
 
-    const next = jest.fn(() => {
+  it('should not call ctx.resolve if stale value does not exists', done => {
+    const mocks = createMocks()
+
+    const next = createNext(done, () => {
       expect(mocks.ctx.resolve).not.toBeCalled()
-      expect(next).toBeCalled()
-      done()
+      expect(mocks.resolveStaleWhileRevalidateEntry).toBeCalledWith(
+        mocks.service,
+        'mockCacheKey',
+        mocks.cache,
+        mocks.ctx
+      )
     })
 
-    CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    mocks.resolveStaleWhileRevalidateEntry.mockReturnValue(undefined)
+    const result = CacheMiddleware.before(mocks.service, mocks.ctx, next)
+    expect(result).toEqual(true)
   })
 })
 
 describe('after', () => {
-  it('should call next if no  ttl', () => {
-    const mocks = createMocks()
-    const next = jest.fn()
-    CacheMiddleware.after(mocks.service, mocks.ctx, next)
-    expect(next).toBeCalledWith() // with no arguments
-  })
-
-  it('should call not call setStaleWhileRevalidateEntry if ttl, staleWhileRevalidate and ctx.locals.revalidatingCache are true', () => {
-    const mocks = createMocks()
-    const next = jest.fn()
-
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.context.params.staleWhileRevalidate = true
-    mocks.ctx.locals.revalidatingCache = true
-    const setStaleWhileRevalidateEntry = jest.spyOn(
-      CacheMiddleware,
-      'setStaleWhileRevalidateEntry'
-    )
-
-    CacheMiddleware.after(mocks.service, mocks.ctx, next)
-    expect(setStaleWhileRevalidateEntry).not.toBeCalled()
-    expect(next).toBeCalled()
-
-    setStaleWhileRevalidateEntry.mockReset()
-    setStaleWhileRevalidateEntry.mockRestore()
-  })
-  it('should call setStaleWhileRevalidateEntry if ttl, staleWhileRevalidate are true and ctx.locals.revalidatingCache is false', done => {
-    const mocks = createMocks()
-
-    mocks.ctx.value = 'VALUE'
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.context.params.staleWhileRevalidate = '10m'
-    mocks.ctx.locals.revalidatingCache = undefined
-    const setStaleWhileRevalidateEntry = jest.spyOn(
-      CacheMiddleware,
-      'setStaleWhileRevalidateEntry'
-    )
-    setStaleWhileRevalidateEntry.mockImplementation(() => Promise.resolve())
-
-    const cache = {
+  function createMocks () {
+    const mocks = {}
+    mocks.ctx = createContext()
+    mocks.ctx.value = 'resolvedValue'
+    mocks.ctx.resolve = jest.fn()
+    mocks.service = {}
+    mocks.cache = {
       ttl: '20m',
-      cacheKey: undefined,
-      useStaleWhileRevalidate: true,
-      staleWhileRevalidateTtl: ms('20m') + ms('10m')
+      cacheKey: () => true,
+      useStaleWhileRevalidate: true
     }
 
-    const next = () => {
-      expect(setStaleWhileRevalidateEntry).toBeCalledWith(
-        mocks.service,
-        'entity:model:Foo',
-        'VALUE',
-        cache
-      )
-      setStaleWhileRevalidateEntry.mockReset()
-      setStaleWhileRevalidateEntry.mockRestore()
-      done()
-    }
+    mocks.next = jest.fn()
 
-    CacheMiddleware.after(mocks.service, mocks.ctx, next)
+    mocks.getCacheParams = jest
+      .spyOn(EntityCacheParams, 'getCacheParams')
+      .mockReturnValue(mocks.cache)
+
+    mocks.generateKey = jest
+      .spyOn(CacheMiddleware, 'generateKey')
+      .mockReturnValue('mockCacheKey')
+
+    mocks.setStaleWhileRevalidateEntry = jest
+      .spyOn(CacheMiddleware, 'setStaleWhileRevalidateEntry')
+      .mockImplementation(() => Promise.resolve())
+
+    mocks.setEntry = jest
+      .spyOn(RedisController, 'setEntry')
+      .mockImplementation(() => Promise.resolve(true))
+
+    return mocks
+  }
+
+  describe('exit to avoid cache process', () => {
+    it('should call next and return false if no ttl', () => {
+      const mocks = createMocks()
+      mocks.cache.ttl = undefined
+      const result = CacheMiddleware.after(mocks.service, mocks.ctx, mocks.next)
+      expect(result).toEqual(false)
+      expect(mocks.next).toBeCalledWith()
+    })
+
+    it('should call next and return false if no ttl', () => {
+      const mocks = createMocks()
+      mocks.ctx.locals.revalidatingCache = true
+      const result = CacheMiddleware.after(mocks.service, mocks.ctx, mocks.next)
+      expect(result).toEqual(false)
+      expect(mocks.next).toBeCalledWith()
+    })
   })
 
-  it('should call not call setStaleWhileRevalidateEntry if ttl is true and staleWhileRevalidate is false, it should do a normal setEntry', done => {
+  it('should set stale value if cache.useStaleWhileRevalidate is true', done => {
     const mocks = createMocks()
 
-    mocks.ctx.value = 'VALUE'
-    mocks.ctx.context.params.ttl = '20m'
-    mocks.ctx.context.params.staleWhileRevalidate = undefined
-    mocks.ctx.locals.revalidatingCache = undefined
-    const setStaleWhileRevalidateEntry = jest.spyOn(
-      CacheMiddleware,
-      'setStaleWhileRevalidateEntry'
-    )
-    mocks.service.cache.set = jest.fn(() => Promise.resolve())
-
-    const next = () => {
-      expect(setStaleWhileRevalidateEntry).not.toBeCalled()
-      expect(mocks.service.cache.set).toBeCalledWith(
-        'entity:model:Foo',
-        'VALUE',
-        '20m'
+    const next = createNext(done, () => {
+      expect(mocks.setStaleWhileRevalidateEntry).toBeCalledWith(
+        mocks.service,
+        'mockCacheKey',
+        'resolvedValue',
+        mocks.cache
       )
-      setStaleWhileRevalidateEntry.mockReset()
-      setStaleWhileRevalidateEntry.mockRestore()
-      done()
-    }
+      expect(mocks.setEntry).not.toBeCalled()
+    })
 
-    CacheMiddleware.after(mocks.service, mocks.ctx, next)
+    mocks.cache.useStaleWhileRevalidate = true
+    const result = CacheMiddleware.after(mocks.service, mocks.ctx, next)
+    expect(result).toEqual(true)
+  })
+
+  it('should set basic redis entry value if cache.useStaleWhileRevalidate is false', done => {
+    const mocks = createMocks()
+
+    const next = createNext(done, () => {
+      expect(mocks.setStaleWhileRevalidateEntry).not.toBeCalled()
+      expect(mocks.setEntry).toBeCalledWith(
+        mocks.service,
+        'mockCacheKey',
+        'resolvedValue',
+        mocks.cache.ttl
+      )
+    })
+
+    mocks.cache.useStaleWhileRevalidate = false
+    const result = CacheMiddleware.after(mocks.service, mocks.ctx, next)
+    expect(result).toEqual(true)
+  })
+
+  describe('handle error', () => {
+    it('should call next with error value if setStaleWhileRevalidateEntry fails', done => {
+      const mocks = createMocks()
+
+      const error = new Error('failed')
+      mocks.setStaleWhileRevalidateEntry.mockImplementation(() =>
+        Promise.reject(error)
+      )
+
+      const next = createNext(done, () => {
+        expect(next).toBeCalledWith(error)
+      })
+
+      mocks.cache.useStaleWhileRevalidate = true
+      const result = CacheMiddleware.after(mocks.service, mocks.ctx, next)
+      expect(result).toEqual(true)
+    })
+
+    it('should call next with error value if setEntry fails', done => {
+      const mocks = createMocks()
+
+      const error = new Error('failed')
+      mocks.setEntry.mockImplementation(() => Promise.reject(error))
+
+      const next = createNext(done, () => {
+        expect(next).toBeCalledWith(error)
+      })
+
+      mocks.cache.useStaleWhileRevalidate = false
+      const result = CacheMiddleware.after(mocks.service, mocks.ctx, next)
+      expect(result).toEqual(true)
+    })
   })
 })

--- a/packages/data-point-service/lib/entity-cache-params.js
+++ b/packages/data-point-service/lib/entity-cache-params.js
@@ -55,6 +55,7 @@ function getCacheParams (params) {
 
   let useStaleWhileRevalidate
   let staleWhileRevalidateTtl
+  let revalidateTimeout
 
   // we only want to calculate below values if ttl is set
   if (typeof ttl !== 'undefined') {
@@ -73,6 +74,9 @@ function getCacheParams (params) {
         staleWhileRevalidate,
         ttl
       )
+
+      // 5 seconds default
+      revalidateTimeout = defaultTo(parseMs(cache.revalidateTimeout), 5000)
     }
   }
 
@@ -80,7 +84,8 @@ function getCacheParams (params) {
     ttl,
     cacheKey: defaultTo(cache.cacheKey, params.cacheKey),
     useStaleWhileRevalidate,
-    staleWhileRevalidateTtl
+    staleWhileRevalidateTtl,
+    revalidateTimeout
   }
 }
 

--- a/packages/data-point-service/lib/entity-cache-params.test.js
+++ b/packages/data-point-service/lib/entity-cache-params.test.js
@@ -1,5 +1,8 @@
 /* eslint-env jest */
 
+const util = require('util')
+util.deprecate = jest.fn(fn => fn)
+
 const EntityCacheParams = require('./entity-cache-params')
 
 describe('warnLooseParamsCacheDeprecation', () => {
@@ -97,7 +100,8 @@ describe('getCacheParams', () => {
       ttl: params.ttl,
       cacheKey: params.cacheKey,
       useStaleWhileRevalidate: true,
-      staleWhileRevalidateTtl: 30000
+      staleWhileRevalidateTtl: 30000,
+      revalidateTimeout: 5000
     })
   })
   it('should get values from params.cache property', () => {
@@ -113,7 +117,8 @@ describe('getCacheParams', () => {
       ttl: params.cache.ttl,
       cacheKey: params.cache.cacheKey,
       useStaleWhileRevalidate: true,
-      staleWhileRevalidateTtl: 30000
+      staleWhileRevalidateTtl: 30000,
+      revalidateTimeout: 5000
     })
   })
   it('should have params.cache priority over loose param cache settings', () => {
@@ -133,9 +138,46 @@ describe('getCacheParams', () => {
       // this key will use the loose value since its not being set through
       // params.cache
       useStaleWhileRevalidate: true,
-      staleWhileRevalidateTtl: 20020
+      staleWhileRevalidateTtl: 20020,
+      revalidateTimeout: 5000
     })
   })
+
+  it('should set params.cache.revalidateTimeout to default if not set', () => {
+    const params = {
+      cache: {
+        ttl: '20s',
+        staleWhileRevalidate: '20ms'
+      }
+    }
+    const cache = EntityCacheParams.getCacheParams(params)
+    expect(cache).toEqual({
+      ttl: params.cache.ttl,
+      cacheKey: undefined,
+      useStaleWhileRevalidate: true,
+      staleWhileRevalidateTtl: 20020,
+      revalidateTimeout: 5000
+    })
+  })
+
+  it('should set params.cache.revalidateTimeout when provided', () => {
+    const params = {
+      cache: {
+        ttl: '20s',
+        staleWhileRevalidate: '20ms',
+        revalidateTimeout: '10m'
+      }
+    }
+    const cache = EntityCacheParams.getCacheParams(params)
+    expect(cache).toEqual({
+      ttl: params.cache.ttl,
+      cacheKey: undefined,
+      useStaleWhileRevalidate: true,
+      staleWhileRevalidateTtl: 20020,
+      revalidateTimeout: 600000
+    })
+  })
+
   it('should not calculate stale values if ttl is not set', () => {
     const params = {
       cache: {}

--- a/packages/data-point-service/lib/no-entry-found.js
+++ b/packages/data-point-service/lib/no-entry-found.js
@@ -1,0 +1,1 @@
+module.exports = Symbol('NO_ENTRY_FOUND')

--- a/packages/data-point-service/lib/redis-controller.js
+++ b/packages/data-point-service/lib/redis-controller.js
@@ -26,6 +26,15 @@ function getEntry (service, key) {
 /**
  * @param {Service} service Service instance
  * @param {String} key entry key
+ * @returns {Promise}
+ */
+function deleteEntry (service, key) {
+  return service.cache.del(key)
+}
+
+/**
+ * @param {Service} service Service instance
+ * @param {String} key entry key
  * @returns {Promise<Object|undefined>} entry value
  */
 function getSWRStaleEntry (service, key) {
@@ -74,9 +83,21 @@ function setSWRControlEntry (service, key, ttl, value) {
   return setEntry(service, createSWRControlKey(key), value, ttl)
 }
 
+/**
+ * @param {Service} service Service instance
+ * @param {String} key entry key
+ * @param {String} ttl time to live value supported by https://github.com/zeit/ms
+ * @returns {Promise}
+ */
+function deleteSWRControlEntry (service, key) {
+  return deleteEntry(service, createSWRControlKey(key))
+}
+
 module.exports = {
   createSWRControlKey,
   createSWRStaleKey,
+  deleteEntry,
+  deleteSWRControlEntry,
   getEntry,
   getSWRControlEntry,
   getSWRStaleEntry,

--- a/packages/data-point-service/lib/redis-controller.test.js
+++ b/packages/data-point-service/lib/redis-controller.test.js
@@ -29,6 +29,33 @@ describe('getEntry', () => {
   })
 })
 
+describe('deletetEntry', () => {
+  it('should call cache.del from service to delete a key', () => {
+    const service = {
+      cache: {
+        del: jest.fn(() => Promise.resolve())
+      }
+    }
+    return RedisController.deleteEntry(service, 'test').then(result => {
+      expect(service.cache.del).toBeCalledWith('test')
+    })
+  })
+})
+
+describe('getSWRStaleEntry', () => {
+  it('should return true if key exists with valid wrapper ', () => {
+    const service = {
+      cache: {
+        get: jest.fn(key => Promise.resolve('SWR-STALE'))
+      }
+    }
+    return RedisController.getSWRStaleEntry(service, 'test').then(result => {
+      expect(service.cache.get).toBeCalledWith('test:swr.stale')
+      expect(result).toEqual('SWR-STALE')
+    })
+  })
+})
+
 describe('getSWRControlEntry', () => {
   it('should return true if key exists with valid wrapper ', () => {
     const service = {
@@ -106,5 +133,17 @@ describe('setSWRControlEntry', () => {
       'SWR-CONTROL',
       200
     )
+  })
+})
+
+describe('deleteSWRControlEntry', () => {
+  it('should create a key that has no ttl', () => {
+    const service = {
+      cache: {
+        del: jest.fn()
+      }
+    }
+    RedisController.deleteSWRControlEntry(service, 'key')
+    expect(service.cache.del).toBeCalledWith('key:swr.control')
   })
 })

--- a/packages/data-point-service/lib/revalidation-store.js
+++ b/packages/data-point-service/lib/revalidation-store.js
@@ -1,0 +1,85 @@
+const debug = require('debug')('data-point-service:cache')
+const throttle = require('lodash/throttle')
+
+const MAX_STORE_SIZE = 10000
+const THROTTLE_WAIT = 1000 // cleanup in every 1 seconds
+
+/**
+ * It marks and deletes all the keys that have their ttl expired
+ * @param {Map} store Map Object that stores all the cached keys
+ */
+function clear (store) {
+  const forDeletion = []
+  const now = Date.now()
+
+  for (const entry of store) {
+    // mark for deletion entries that have timed out
+    if (now - entry[1][0] > entry[1][1]) {
+      forDeletion.push(entry[0])
+    }
+  }
+
+  if (forDeletion.length > 0) {
+    debug(`local revalidation flags that timed out: ${forDeletion}`)
+  }
+
+  forDeletion.forEach(key => store.delete(key))
+}
+
+/**
+ * @param {Map} store Map Object that stores all the cached keys
+ * @param {Number} maxStoreSize Size to limit the store, if above this number keys will no longer be saved
+ * @param {String} key key value
+ * @param {Number} ttl time the key will be alive, expressed in milliseconds
+ */
+function add (store, maxStoreSize, key, ttl) {
+  // do not add more than 10000 keys
+  if (store.size > maxStoreSize) return false
+  store.set(key, [Date.now(), ttl])
+  return true
+}
+
+/**
+ * @param {Map} store Map Object that stores all the cached keys
+ * @param {String} key key value
+ */
+function remove (store, key) {
+  store.delete(key)
+  return true
+}
+
+/**
+ * True if a key exists, and it has not expired
+ * @param {Map} store Map Object that stores all the cached keys
+ * @param {String} key key value
+ */
+function exists (store, key) {
+  const entry = store.get(key)
+  // checks entry exists and it has not timed-out
+  return !!entry && Date.now() - entry[0] < entry[1]
+}
+
+/**
+ * Creates an in-memory Revalidation Controller
+ */
+function create () {
+  const store = new Map()
+
+  return {
+    store,
+    add: add.bind(null, store, MAX_STORE_SIZE),
+    remove: remove.bind(null, store),
+    exists: exists.bind(null, store),
+    clear: throttle(clear.bind(null, store), THROTTLE_WAIT)
+  }
+}
+
+module.exports = {
+  MAX_STORE_SIZE,
+  THROTTLE_WAIT,
+  clear,
+  add,
+  remove,
+  exists,
+  create
+}

--- a/packages/data-point-service/lib/revalidation-store.test.js
+++ b/packages/data-point-service/lib/revalidation-store.test.js
@@ -10,7 +10,7 @@ jest.mock('lodash/throttle', () => {
   return mockThrottle
 })
 jest.mock('lodash/throttle', () => {
-  return mockthrottle
+  return mockThrottle
 })
 
 describe('add', () => {
@@ -19,8 +19,8 @@ describe('add', () => {
     const store = new Map()
     RevalidationStore.add(store, 10, 'test', 1000)
     const result = store.get('test')
-    expect(typeof result[0]).toEqual('number')
-    expect(result[1]).toEqual(1000)
+    expect(typeof result.created).toEqual('number')
+    expect(result.ttl).toEqual(1000)
   })
   it('should not add key if store size is more than MAX_STORE_SIZE', () => {
     const RevalidationStore = require('./revalidation-store')
@@ -47,7 +47,7 @@ describe('exists', () => {
   it('should check if key exists and has not expired', () => {
     const RevalidationStore = require('./revalidation-store')
     const store = new Map()
-    store.set('foo', [Date.now() + 100000, 100])
+    store.set('foo', { created: Date.now() + 100000, ttl: 100 })
     expect(RevalidationStore.exists(store, 'foo')).toEqual(true)
   })
 
@@ -90,7 +90,7 @@ describe('clear', () => {
   it('should remove expired keys', () => {
     const RevalidationStore = require('./revalidation-store')
     const store = new Map()
-    store.set('t2', [NOW - 10, 2]) // expired
+    store.set('t2', { created: NOW - 10, ttl: 2 }) // expired
     RevalidationStore.clear(store)
     expect(store.size).toEqual(0)
     expect(mockDebug).toBeCalled()
@@ -100,8 +100,8 @@ describe('clear', () => {
   it('should remove only expired keys', () => {
     const RevalidationStore = require('./revalidation-store')
     const store = new Map()
-    store.set('t1', [NOW, 2]) // has not expired
-    store.set('t2', [NOW - 10, 2]) // expired
+    store.set('t1', { created: NOW, ttl: 2 }) // has not expired
+    store.set('t2', { created: NOW - 10, ttl: 2 }) // expired
     RevalidationStore.clear(store)
     expect(store.size).toEqual(1)
     expect(store.get('t1')).not.toBeUndefined()
@@ -134,7 +134,7 @@ describe('create', () => {
       const store = RevalidationStore.create()
 
       store.add('t1', 100)
-      expect(store.store.get('t1')).toEqual([NOW, 100])
+      expect(store.store.get('t1')).toEqual({ created: NOW, ttl: 100 })
     })
 
     it('should remove entry', () => {

--- a/packages/data-point-service/lib/revalidation-store.test.js
+++ b/packages/data-point-service/lib/revalidation-store.test.js
@@ -5,7 +5,10 @@ jest.mock('debug', () => {
   return () => mockDebug
 })
 
-const mockthrottle = jest.fn(fn => fn)
+const mockThrottle = jest.fn(fn => fn)
+jest.mock('lodash/throttle', () => {
+  return mockThrottle
+})
 jest.mock('lodash/throttle', () => {
   return mockthrottle
 })

--- a/packages/data-point-service/lib/revalidation-store.test.js
+++ b/packages/data-point-service/lib/revalidation-store.test.js
@@ -1,0 +1,169 @@
+/* eslint-env jest */
+
+const mockDebug = jest.fn()
+jest.mock('debug', () => {
+  return () => mockDebug
+})
+
+const mockthrottle = jest.fn(fn => fn)
+jest.mock('lodash/throttle', () => {
+  return mockthrottle
+})
+
+describe('add', () => {
+  it('should add key if store size is less than MAX_STORE_SIZE', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    RevalidationStore.add(store, 10, 'test', 1000)
+    const result = store.get('test')
+    expect(typeof result[0]).toEqual('number')
+    expect(result[1]).toEqual(1000)
+  })
+  it('should not add key if store size is more than MAX_STORE_SIZE', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('foo', 'bar')
+    store.set('baz', 'bar')
+    const result = RevalidationStore.add(store, 1, 'test', 1000)
+    expect(store.get('test')).toBeUndefined()
+    expect(result).toEqual(false)
+  })
+})
+
+describe('remove', () => {
+  it('should remove a key from the map', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('foo', 'bar')
+    RevalidationStore.remove(store, 'foo')
+    expect(store.get('foo')).toBeUndefined()
+  })
+})
+
+describe('exists', () => {
+  it('should check if key exists and has not expired', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('foo', [Date.now() + 100000, 100])
+    expect(RevalidationStore.exists(store, 'foo')).toEqual(true)
+  })
+
+  it('should check if key does not exists', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    expect(RevalidationStore.exists(store, 'foo')).toEqual(false)
+  })
+
+  it('should check if key has expired', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('foo', [Date.now() - 100000, 100])
+    expect(RevalidationStore.exists(store, 'foo')).toEqual(false)
+  })
+})
+
+describe('clear', () => {
+  let mockDate
+
+  const NOW = 1000
+
+  beforeEach(() => {
+    mockDate = jest.spyOn(Date, 'now').mockImplementation(() => NOW)
+    mockDebug.mockReset()
+  })
+
+  afterEach(() => {
+    mockDate.mockRestore()
+  })
+
+  it('should not removed keys that have not expired', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('t1', [NOW, 2]) // has not expired
+    RevalidationStore.clear(store)
+    expect(store.size).toEqual(1)
+  })
+
+  it('should remove expired keys', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('t2', [NOW - 10, 2]) // expired
+    RevalidationStore.clear(store)
+    expect(store.size).toEqual(0)
+    expect(mockDebug).toBeCalled()
+    expect(mockDebug.mock.calls).toMatchSnapshot()
+  })
+
+  it('should remove only expired keys', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = new Map()
+    store.set('t1', [NOW, 2]) // has not expired
+    store.set('t2', [NOW - 10, 2]) // expired
+    RevalidationStore.clear(store)
+    expect(store.size).toEqual(1)
+    expect(store.get('t1')).not.toBeUndefined()
+  })
+})
+
+describe('create', () => {
+  let mockDate
+
+  const NOW = 1000
+
+  beforeEach(() => {
+    mockDate = jest.spyOn(Date, 'now').mockImplementation(() => NOW)
+    mockDebug.mockReset()
+  })
+
+  afterEach(() => {
+    mockDate.mockRestore()
+  })
+
+  it('should create a new store that matches snapshot api', () => {
+    const RevalidationStore = require('./revalidation-store')
+    const store = RevalidationStore.create()
+    expect(store).toMatchSnapshot()
+  })
+
+  describe('implementation', () => {
+    it('should add new entry', () => {
+      const RevalidationStore = require('./revalidation-store')
+      const store = RevalidationStore.create()
+
+      store.add('t1', 100)
+      expect(store.store.get('t1')).toEqual([NOW, 100])
+    })
+
+    it('should remove entry', () => {
+      const RevalidationStore = require('./revalidation-store')
+      const store = RevalidationStore.create()
+
+      store.remove('t1')
+      expect(store.store.get('t1')).toBeUndefined()
+    })
+
+    it('should check if entry exists', () => {
+      const RevalidationStore = require('./revalidation-store')
+      const store = RevalidationStore.create()
+
+      store.add('t2', 100)
+      expect(store.exists('t2')).toEqual(true)
+      expect(store.exists('t1')).toEqual(false)
+
+      // check expired
+      store.add('t3', -100)
+      expect(store.exists('t3')).toEqual(false)
+    })
+
+    it('should clear entries', () => {
+      const RevalidationStore = require('./revalidation-store')
+      const store = RevalidationStore.create()
+
+      store.add('t1', 100)
+      store.add('t2', -100)
+
+      store.clear()
+      expect(store.store).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/data-point-service/lib/stale-while-revalidate.js
+++ b/packages/data-point-service/lib/stale-while-revalidate.js
@@ -81,7 +81,7 @@ function getEntry (service, entryKey) {
  * @returns {Promise}
  */
 function addRevalidationFlags (revalidation, entryKey, revalidateTimeout) {
-  // local (node instance) flag is set to imediatly prevent concurrent calls
+  // local (node instance) flag is set to immediately prevent concurrent calls
   revalidation.local.add(entryKey, revalidateTimeout)
   // external (redis) flag is set to prevent multiple instances from duplicating
   // revalidation efforts

--- a/packages/data-point-service/lib/stale-while-revalidate.js
+++ b/packages/data-point-service/lib/stale-while-revalidate.js
@@ -1,0 +1,170 @@
+const revalidationStoreFactory = require('./revalidation-store').create
+
+const RedisController = require('./redis-controller')
+
+/**
+ * Flag for redis control entry flag, when set it means the stored result should
+ * be considered stale
+ */
+const SWR_CONTROL_STALE = 'SWR-CONTROL-STALE'
+
+/**
+ * Flag for redis control entry flag, when set it means the stored result should
+ * be considered in revalidation state. Revalidation state is stored to prevent
+ * duplication of concurrent revalidations by multiple node instances.
+ */
+const SWR_CONTROL_REVALIDATING = 'SWR-CONTROL-REVALIDATING'
+
+/**
+ * @param {Service} service Service instance
+ * @returns {Object} External (redis) revalidation controller
+ */
+function revalidationExternalFactory (service) {
+  return {
+    add: (entryKey, ttl) => {
+      return RedisController.setSWRControlEntry(
+        service,
+        entryKey,
+        ttl,
+        SWR_CONTROL_REVALIDATING
+      )
+    },
+    remove: entryKey => {
+      return RedisController.deleteSWRControlEntry(service, entryKey)
+    },
+    exists: entryKey => {
+      return RedisController.getSWRControlEntry(service, entryKey).then(
+        value => typeof value !== 'undefined'
+      )
+    }
+  }
+}
+
+/**
+ * @param {Service} service Service instance
+ * @param {String} entryKey entry key
+ * @param {Object} value entry value
+ * @param {Object} cache cache configuration
+ * @returns {Promise}
+ */
+function addEntry (service, entryKey, value, cache) {
+  return RedisController.setSWRStaleEntry(
+    service,
+    entryKey,
+    value,
+    cache.staleWhileRevalidateTtl
+  ).then(() =>
+    RedisController.setSWRControlEntry(
+      service,
+      entryKey,
+      cache.ttl,
+      SWR_CONTROL_STALE
+    )
+  )
+}
+
+/**
+ * @param {Service} service Service instance
+ * @param {String} entryKey entry key
+ * @returns {Promise}
+ */
+function getEntry (service, entryKey) {
+  return RedisController.getSWRStaleEntry(service, entryKey)
+}
+
+/**
+ * Adds revalidation flags locally (node instance) and external (redis) to
+ * prevent duplicated revalidations of same key.
+ * @param {Object} revalidation revalidation API
+ * @param {String} entryKey cache entry key
+ * @param {Number} revalidateTimeout time to timeout revalidation in milliseconds
+ * @returns {Promise}
+ */
+function addRevalidationFlags (revalidation, entryKey, revalidateTimeout) {
+  // local (node instance) flag is set to imediatly prevent concurrent calls
+  revalidation.local.add(entryKey, revalidateTimeout)
+  // external (redis) flag is set to prevent multiple instances from duplicating
+  // revalidation efforts
+  return revalidation.external.add(entryKey, revalidateTimeout)
+}
+
+/**
+ * @param {Object} revalidation revalidation API
+ * @param {String} entryKey cache entry key
+ */
+function clearAllRevalidationFlags (revalidation, entryKey) {
+  revalidation.local.remove(entryKey)
+  return revalidation.external.remove(entryKey)
+}
+
+/**
+ * @typedef {Object} RevalidationState
+ * @property {Boolean} hasExternalEntryExpired has external control expired
+ * @property {Function} isRevalidatingLocally checks if key is being locally revalidated
+ */
+/**
+ * Get local and external revalidation state
+ * @param {Service} service cache service instance
+ * @param {DataPoint.Accumulator} ctx DataPoint Accumulator object
+ * @param {String} entryKey cache entry key
+ * @returns {Promise<RevalidationState>} Object with revalidation state
+ */
+function getRevalidationState (revalidation, entryKey) {
+  return revalidation.external
+    .exists(entryKey)
+    .then(hasExternalEntryExpired => {
+      return {
+        hasExternalEntryExpired,
+        isRevalidatingLocally: () => revalidation.local.exists(entryKey)
+      }
+    })
+}
+
+/**
+ * @typedef {Object} RevalidationManager
+ * @property {Object} local local cache controller
+ * @property {Object} external external cache controller
+ */
+/**
+ * @param {Service} service cache service instance
+ * @returns {RevalidationManager}
+ */
+function createRevalidationManager (service) {
+  return {
+    local: revalidationStoreFactory(),
+    external: revalidationExternalFactory(service)
+  }
+}
+
+/**
+ * @param {Service} service cache service instance
+ * @returns {Object} Stale While Revalidate Controller
+ */
+function create (service) {
+  const revalidation = createRevalidationManager(service)
+  return {
+    addEntry: addEntry.bind(null, service),
+    getEntry: getEntry.bind(null, service),
+    addRevalidationFlags: addRevalidationFlags.bind(null, revalidation),
+    clearAllRevalidationFlags: clearAllRevalidationFlags.bind(
+      null,
+      revalidation
+    ),
+    invalidateLocalFlags: revalidation.local.clear,
+    removeLocalRevalidationFlag: revalidation.local.remove,
+    getRevalidationState: getRevalidationState.bind(null, revalidation)
+  }
+}
+
+module.exports = {
+  SWR_CONTROL_STALE,
+  SWR_CONTROL_REVALIDATING,
+  revalidationExternalFactory,
+  addRevalidationFlags,
+  clearAllRevalidationFlags,
+  getRevalidationState,
+  createRevalidationManager,
+  addEntry,
+  getEntry,
+  create
+}

--- a/packages/data-point-service/lib/stale-while-revalidate.test.js
+++ b/packages/data-point-service/lib/stale-while-revalidate.test.js
@@ -203,10 +203,10 @@ describe('getRevalidationState', () => {
 
 describe('createRevalidationManager', () => {
   it('should create revalidation controller', () => {
-    const reavidation = StaleWhileRevalidate.createRevalidationManager()
+    const revalidation = StaleWhileRevalidate.createRevalidationManager()
 
-    expect(reavidation).toHaveProperty('local.add')
-    expect(reavidation).toHaveProperty('external.add')
+    expect(revalidation).toHaveProperty('local.add')
+    expect(revalidation).toHaveProperty('external.add')
   })
 })
 

--- a/packages/data-point-service/lib/stale-while-revalidate.test.js
+++ b/packages/data-point-service/lib/stale-while-revalidate.test.js
@@ -1,0 +1,218 @@
+/* eslint-env jest */
+const _ = require('lodash')
+
+const mockDebug = jest.fn()
+jest.mock('debug', () => {
+  return () => mockDebug
+})
+
+const mockLocalAdd = jest.fn()
+const mockLocalRemove = jest.fn()
+require('./revalidation-store')
+jest.mock('./revalidation-store', () => {
+  return {
+    create: () => ({
+      add: mockLocalAdd,
+      remove: mockLocalRemove,
+      clear: () => {}
+    })
+  }
+})
+
+const RedisController = require('./redis-controller')
+
+const StaleWhileRevalidate = require('./stale-while-revalidate')
+
+beforeEach(() => {
+  jest.resetModules()
+  delete require.cache[require.resolve('./stale-while-revalidate')]
+})
+
+describe('revalidationExternalFactory', () => {
+  describe('add - add remote revalidation flag', () => {
+    it('should call setSWRControlEntry', () => {
+      const mockSetSWRControlEntry = jest
+        .spyOn(RedisController, 'setSWRControlEntry')
+        .mockImplementation(() => true)
+
+      const external = StaleWhileRevalidate.revalidationExternalFactory(
+        'service'
+      )
+
+      expect(external.add('entryKey', 'ttl')).toEqual(true)
+      expect(mockSetSWRControlEntry).toBeCalledWith(
+        'service',
+        'entryKey',
+        'ttl',
+        StaleWhileRevalidate.SWR_CONTROL_REVALIDATING
+      )
+    })
+  })
+
+  describe('remove - remove remote revalidation flag', () => {
+    it('should call setSWRControlEntry', () => {
+      const mockDeleteSWRControlEntry = jest
+        .spyOn(RedisController, 'deleteSWRControlEntry')
+        .mockImplementation(() => true)
+
+      const external = StaleWhileRevalidate.revalidationExternalFactory(
+        'service'
+      )
+
+      expect(external.remove('entryKey', 'ttl')).toEqual(true)
+      expect(mockDeleteSWRControlEntry).toBeCalledWith('service', 'entryKey')
+    })
+  })
+
+  describe('exists - check if remote revalidation flag exists', () => {
+    it('should return true if value is not undefined', () => {
+      const mockGetSWRControlEntry = jest
+        .spyOn(RedisController, 'getSWRControlEntry')
+        .mockImplementation(() => Promise.resolve('foo'))
+
+      const external = StaleWhileRevalidate.revalidationExternalFactory(
+        'service'
+      )
+
+      return external.exists('entryKey').then(result => {
+        expect(result).toEqual(true)
+        expect(mockGetSWRControlEntry).toBeCalledWith('service', 'entryKey')
+      })
+    })
+
+    it('should return false if value is undefined', () => {
+      jest
+        .spyOn(RedisController, 'getSWRControlEntry')
+        .mockImplementation(() => Promise.resolve(undefined))
+
+      const external = StaleWhileRevalidate.revalidationExternalFactory(
+        'service'
+      )
+
+      return external.exists('entryKey').then(result => {
+        expect(result).toEqual(false)
+      })
+    })
+  })
+})
+
+describe('addEntry', () => {
+  it('should add an entry to redis', () => {
+    const mockSetSWRStaleEntry = jest
+      .spyOn(RedisController, 'setSWRStaleEntry')
+      .mockImplementation(() => Promise.resolve(true))
+
+    const mockSetSWRControlEntry = jest
+      .spyOn(RedisController, 'setSWRControlEntry')
+      .mockImplementation(() => Promise.resolve(true))
+
+    const cache = {
+      ttl: '10s',
+      staleWhileRevalidateTtl: '20s'
+    }
+
+    return StaleWhileRevalidate.addEntry(
+      'service',
+      'entryKey',
+      'value',
+      cache
+    ).then(result => {
+      expect(mockSetSWRStaleEntry).toBeCalledWith(
+        'service',
+        'entryKey',
+        'value',
+        cache.staleWhileRevalidateTtl
+      )
+      expect(mockSetSWRControlEntry).toBeCalledWith(
+        'service',
+        'entryKey',
+        cache.ttl,
+        StaleWhileRevalidate.SWR_CONTROL_STALE
+      )
+    })
+  })
+})
+
+describe('getEntry', () => {
+  it('should add an entry to redis', () => {
+    const getSWRStaleEntry = jest
+      .spyOn(RedisController, 'getSWRStaleEntry')
+      .mockImplementation(() => Promise.resolve(true))
+
+    return StaleWhileRevalidate.getEntry('service', 'entryKey', 'value').then(
+      result => {
+        expect(getSWRStaleEntry).toBeCalledWith('service', 'entryKey')
+      }
+    )
+  })
+})
+
+describe('addRevalidationFlags', () => {
+  it('should add local and external flags', () => {
+    const revalidation = {}
+    _.set(revalidation, 'local.add', jest.fn())
+    _.set(revalidation, 'external.add', jest.fn(() => Promise.resolve(true)))
+
+    return StaleWhileRevalidate.addRevalidationFlags(
+      revalidation,
+      'entryKey',
+      '10s'
+    ).then(() => {
+      expect(revalidation.local.add).toBeCalledWith('entryKey', '10s')
+      expect(revalidation.external.add).toBeCalledWith('entryKey', '10s')
+    })
+  })
+})
+
+describe('clearAllRevalidationFlags', () => {
+  it('should clear local and external flags', () => {
+    const revalidation = {}
+    _.set(revalidation, 'local.remove', jest.fn())
+    _.set(revalidation, 'external.remove', jest.fn(() => Promise.resolve(true)))
+
+    return StaleWhileRevalidate.clearAllRevalidationFlags(
+      revalidation,
+      'entryKey'
+    ).then(() => {
+      expect(revalidation.local.remove).toBeCalledWith('entryKey')
+      expect(revalidation.external.remove).toBeCalledWith('entryKey')
+    })
+  })
+})
+
+describe('getRevalidationState', () => {
+  it('should get local and external flag states', () => {
+    const revalidation = {}
+    _.set(revalidation, 'local.exists', jest.fn(() => 'localState'))
+    _.set(
+      revalidation,
+      'external.exists',
+      jest.fn(() => Promise.resolve('externalState'))
+    )
+
+    return StaleWhileRevalidate.getRevalidationState(
+      revalidation,
+      'entryKey'
+    ).then(result => {
+      expect(result.hasExternalEntryExpired).toEqual('externalState')
+      expect(result.isRevalidatingLocally).toBeInstanceOf(Function)
+      expect(result.isRevalidatingLocally()).toEqual('localState')
+    })
+  })
+})
+
+describe('createRevalidationManager', () => {
+  it('should create revalidation controller', () => {
+    const reavidation = StaleWhileRevalidate.createRevalidationManager()
+
+    expect(reavidation).toHaveProperty('local.add')
+    expect(reavidation).toHaveProperty('external.add')
+  })
+})
+
+describe('create', () => {
+  it('should create stale while revalidate controller', () => {
+    const swr = StaleWhileRevalidate.create()
+    expect(swr).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
closes #303

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:  prevents duplicate revalidations from happening when concurrent calls happen to access the same key

<!-- Why are these changes necessary? -->
**Why**: when concurrent calls are made, duplicate revalidations may trigger causing reace-condition and waste of resources

<!-- How were these changes implemented? -->
**How**: adding a local and remote (redis) flags to tell the system when a key is being revalidated and prevent new revalidations to happen while a current revalidation is in place

Adds a new parameter called `revalidationTimeout` explained on the README changes.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes N/A
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list N/A

<!-- feel free to add additional comments -->
