### PR TITLE
refactor: Remove deprecated assert.equal and assert.deepEqual functions

### DIFF
--- a/packages/bench-trial/examples/manual-tests.js
+++ b/packages/bench-trial/examples/manual-tests.js
@@ -16,7 +16,7 @@ module.exports = [
   {
     async: false,
     name: 'addsNumbersSync',
-    test: () => assert.deepEqual(addsNumbersSync(), expected),
+    test: () => assert.deepStrictEqual(addsNumbersSync(), expected),
     benchmark: addsNumbersSync
   },
   {
@@ -24,7 +24,7 @@ module.exports = [
     name: 'addsNumbersAsync',
     test: done => {
       addsNumbersAsync((e, val) => {
-        assert.deepEqual(val, expected)
+        assert.deepStrictEqual(val, expected)
         done(null)
       })
     },

--- a/packages/bench-trial/lib/index.js
+++ b/packages/bench-trial/lib/index.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 
 function testSync (method, expected) {
-  return () => assert.deepEqual(method(), expected)
+  return () => assert.deepStrictEqual(method(), expected)
 }
 
 function testAsync (method, expected) {
@@ -11,7 +11,7 @@ function testAsync (method, expected) {
         return done(err)
       }
       try {
-        assert.deepEqual(value, expected)
+        assert.deepStrictEqual(value, expected)
         done(null, value)
       } catch (e) {
         done(e)

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -496,7 +496,7 @@ A path reducer is a `string` that extracts a path from the current [Accumulator]
   dataPoint
     .resolve('$', input)
     .then((output) => {
-      assert.equal(output, input)
+      assert.strictEqual(output, input)
     })
   ```
 </details>
@@ -522,7 +522,7 @@ A path reducer is a `string` that extracts a path from the current [Accumulator]
   dataPoint
     .resolve('$..value', input)
     .then(output => {
-      assert.equal(output input)
+      assert.strictEqual(output input)
     })
   ```
 </details>
@@ -548,7 +548,7 @@ A path reducer is a `string` that extracts a path from the current [Accumulator]
   dataPoint
     .resolve('$a.b[0]', input)
     .then(output => {
-      assert.equal(output, 'Hello World')
+      assert.strictEqual(output, 'Hello World')
     })
   ```
 </details>
@@ -586,7 +586,7 @@ Example at: [examples/reducer-path.js](examples/reducer-path.js)
   dataPoint
     .resolve('$a.b[]', input)
     .then(output => {
-      assert.deepEqual(output, ['Hello World', 'Hello Solar System', 'Hello Universe'])
+      assert.deepStrictEqual(output, ['Hello World', 'Hello Solar System', 'Hello Universe'])
     })
   ```
 </details>
@@ -633,7 +633,7 @@ const name = (input:*, acc:Accumulator) => {
   dataPoint
     .resolve(reducer, 'Hello')
     .then((output) => {
-      assert.equal(output, 'Hello World')
+      assert.strictEqual(output, 'Hello World')
     })
   ```
 </details>
@@ -672,7 +672,7 @@ const name = (input:*, acc:Accumulator) => {
   dataPoint
     .resolve(reducer, 'Hello')
     .then((output) => {
-      assert.equal(output, 'Hello World')
+      assert.strictEqual(output, 'Hello World')
     })
   ```
 </details>
@@ -711,7 +711,7 @@ const name = (input:*, acc:Accumulator, next:function) => {
   dataPoint
     .resolve(reducer, 'Hello')
     .then((output) => {
-      assert.equal(output, 'Hello World')
+      assert.strictEqual(output, 'Hello World')
     })
   ```
 </details>
@@ -949,7 +949,7 @@ See the [Entities](#entities) section for information about the supported entity
   dataPoint
     .resolve([PersonRequest, PersonModel], 1)
     .then((output) => {
-      assert.deepEqual(output, {
+      assert.deepStrictEqual(output, {
         name: 'Luke Skywalker',
         birthYear: '19BBY'
       })
@@ -1006,7 +1006,7 @@ See the [Entities](#entities) section for information about the supported entity
   dataPoint
     .resolve(['reducer:getGreeting | reducer:toUpperCase'], input)
     .then((output) => {
-      assert.equal(output, 'HELLO WORLD')
+      assert.strictEqual(output, 'HELLO WORLD')
     })
   ```
 </details>
@@ -1035,10 +1035,10 @@ See the [Entities](#entities) section for information about the supported entity
   dataPoint
     .resolve(['$a | reducer:toUpperCase[]'], input)
     .then((output) => {
-      assert.equal(output[0], 'HELLO WORLD')
-      assert.equal(output[1], 'HELLO LAIA')
-      assert.equal(output[2], 'HELLO DAREK')
-      assert.equal(output[3], 'HELLO ITALY')
+      assert.strictEqual(output[0], 'HELLO WORLD')
+      assert.strictEqual(output[1], 'HELLO LAIA')
+      assert.strictEqual(output[2], 'HELLO DAREK')
+      assert.strictEqual(output[3], 'HELLO ITALY')
     })
   ```
 </details>
@@ -1097,7 +1097,7 @@ dataPoint.addEntities({
 dataPoint
   .resolve('reducer:getPerson[]', people)
   .then((output) => {
-    assert.deepEqual(output, [
+    assert.deepStrictEqual(output, [
       {
         name: 'Luke Skywalker',
         birthYear: '19BBY'
@@ -1758,7 +1758,7 @@ dataPoint.addEntities({
   dataPoint
     .resolve('reducer:foo', input)
     .then((output) => {
-      assert.equal(output, 30)
+      assert.strictEqual(output, 30)
     })
   ```
 </details>
@@ -1826,7 +1826,7 @@ dataPoint.addEntities({
   dataPoint
     .resolve('model:foo', input)
     .then((output) => {
-      assert.equal(output, 30)
+      assert.strictEqual(output, 30)
     })
   ```
 </details>
@@ -1856,7 +1856,7 @@ Example at: [examples/entity-model-basic.js](examples/entity-model-basic.js)
   dataPoint
     .resolve('model:foo', 100)
     .then((output) => {
-      assert.deepEqual(output, [100])
+      assert.deepStrictEqual(output, [100])
     })
   ```
 </details>
@@ -1892,7 +1892,7 @@ Example at: [examples/entity-model-before.js](examples/entity-model-before.js)
   dataPoint
     .resolve('model:foo', input)
     .then((output) => {
-      assert.deepEqual(output, [3, 15])
+      assert.deepStrictEqual(output, [3, 15])
     })
   ```
 </details>
@@ -1943,7 +1943,7 @@ Passing a value as the second argument will stop the propagation of the error.
   dataPoint
     .resolve('model:getArray', input)
     .then((output) => {
-      assert.deepEqual(output, [])
+      assert.deepStrictEqual(output, [])
     })
   ```
 </details>
@@ -2009,7 +2009,7 @@ The params object is used to pass custom data to your entity. This Object is exp
   dataPoint
     .resolve('model:multiply', 200)
     .then((output) => {
-      assert.deepEqual(output, 20000)
+      assert.deepStrictEqual(output, 20000)
     })
   ```
 </details>
@@ -2030,7 +2030,7 @@ The params object is used to pass custom data to your entity. This Object is exp
   
   dataPoint.resolve('model:getParam')
     .then((output) => {
-      assert.deepEqual(output, 100)
+      assert.deepStrictEqual(output, 100)
     })
   ```
 </details>
@@ -2245,7 +2245,7 @@ For more information on acc.locals: [Transform Options](#transform-options) and 
   dataPoint
     .resolve('request:searchPeople', input)
     .then(output => {
-      assert.equal(output.results[0].name, 'R2-D2')
+      assert.strictEqual(output.results[0].name, 'R2-D2')
     })
   ```
 </details>
@@ -2349,7 +2349,7 @@ Hash entities expose a set of optional reducers: [mapKeys](#hashmapkeys), [omitK
   dataPoint
     .resolve('hash:helloWorld', input)
     .then((output) => {
-      assert.deepEqual(output, {
+      assert.deepStrictEqual(output, {
         c: 'Hello',
         d: ' World!!'
       })
@@ -2396,7 +2396,7 @@ Going back to our GitHub API examples, let's map some keys from the result of a 
   }
 
   dataPoint.resolve('hash:mapKeys', input).then(output => {
-    assert.deepEqual(output, {
+    assert.deepStrictEqual(output, {
       name: 'DataPoint',
       url: 'https://github.com/ViacomInc/data-point'
     })
@@ -2431,7 +2431,7 @@ Hash.addKeys is very similar to Hash.mapKeys, but the difference is that `mapKey
   }
 
   dataPoint.resolve('hash:addKeys', input).then(output => {
-    assert.deepEqual(output, {
+    assert.deepStrictEqual(output, {
       name: 'DataPoint',
       nameLowerCase: 'datapoint',
       url: 'https://github.com/ViacomInc/data-point'
@@ -2467,7 +2467,7 @@ The next example is similar to the previous example. However, instead of mapping
   dataPoint.resolve('hash:pickKeys', input).then(output => {
     // notice how name is no longer 
     // in the object
-    assert.deepEqual(output, {
+    assert.deepStrictEqual(output, {
       url: 'https://github.com/ViacomInc/data-point'
     })
   })
@@ -2504,7 +2504,7 @@ This example will only **omit** some keys, and let the rest pass through:
   }
 
   dataPoint.resolve('hash:omitKeys', input).then(output => {
-    assert.deepEqual(output, expectedResult)
+    assert.deepStrictEqual(output, expectedResult)
   })
   ```
 </details>
@@ -2545,7 +2545,7 @@ Sometimes you just want to add a hard-coded value to your current `acc.value`.
   dataPoint
     .resolve('hash:addValues')
     .then((output) => {
-      assert.deepEqual(output, expectedResult)
+      assert.deepStrictEqual(output, expectedResult)
     })
   ```
 </details>
@@ -2595,7 +2595,7 @@ You can add multiple reducers to your Hash spec.
   dataPoint
     .resolve('entry:orgInfo', { org: 'nodejs' })
     .then((output) => {
-      assert.deepEqual(output, expectedResult)
+      assert.deepStrictEqual(output, expectedResult)
     })
   ```
 </details>
@@ -3505,7 +3505,7 @@ function resolve(acc:Accumulator, resolveReducer:function):Promise<Accumulator>
   dataPoint
     .resolve('render:HelloWorld', input)
     .then((output) => {
-      assert.equal(output, '<h1>Hello World!!</h1>')
+      assert.strictEqual(output, '<h1>Hello World!!</h1>')
     })
   ```
 </details>
@@ -3628,7 +3628,7 @@ const name = (param1, param2, ...) => (input:*, acc:Accumulator, next:function) 
   dataPoint
     .resolve(addStr(' World!!'), 'Hello')
     .then((output) => {
-      assert.equal(output, 'Hello World!!')
+      assert.strictEqual(output, 'Hello World!!')
     })
   ```
 </details>

--- a/packages/data-point/examples/entity-hash-addKeys.js
+++ b/packages/data-point/examples/entity-hash-addKeys.js
@@ -21,6 +21,6 @@ const input = {
 }
 
 dataPoint.resolve('hash:addKeys', input).then(output => {
-  assert.deepEqual(output, expectedResult)
+  assert.deepStrictEqual(output, expectedResult)
   console.log(output)
 })

--- a/packages/data-point/examples/entity-hash-compose.js
+++ b/packages/data-point/examples/entity-hash-compose.js
@@ -35,7 +35,7 @@ const expectedResult = {
 
 dataPoint.resolve('hash:composeExmple', input).then(output => {
   console.log(output)
-  assert.deepEqual(output, expectedResult)
+  assert.deepStrictEqual(output, expectedResult)
   /*
   {
     orgName: 'Node.js Foundation',

--- a/packages/data-point/examples/entity-hash-context.js
+++ b/packages/data-point/examples/entity-hash-context.js
@@ -17,7 +17,7 @@ dataPoint.addEntities({
 })
 
 dataPoint.resolve('hash:helloWorld', input).then(output => {
-  assert.deepEqual(output, {
+  assert.deepStrictEqual(output, {
     c: 'Hello',
     d: ' World!!'
   })

--- a/packages/data-point/examples/entity-hash-mapKeys.js
+++ b/packages/data-point/examples/entity-hash-mapKeys.js
@@ -26,6 +26,6 @@ const input = {
 }
 
 dataPoint.resolve('hash:mapKeys', input).then(output => {
-  assert.deepEqual(output, expectedResult)
+  assert.deepStrictEqual(output, expectedResult)
   console.log(output)
 })

--- a/packages/data-point/examples/entity-hash-omitKeys.js
+++ b/packages/data-point/examples/entity-hash-omitKeys.js
@@ -18,6 +18,6 @@ const input = {
 }
 
 dataPoint.resolve('hash:omitKeys', input).then(output => {
-  assert.deepEqual(output, expectedResult)
+  assert.deepStrictEqual(output, expectedResult)
   console.log(output)
 })

--- a/packages/data-point/examples/entity-hash-pickKeys.js
+++ b/packages/data-point/examples/entity-hash-pickKeys.js
@@ -18,6 +18,6 @@ const input = {
 }
 
 dataPoint.resolve('hash:pickKeys', input).then(output => {
-  assert.deepEqual(output, expectedResult)
+  assert.deepStrictEqual(output, expectedResult)
   console.log(output)
 })

--- a/packages/data-point/examples/entity-model-basic.js
+++ b/packages/data-point/examples/entity-model-basic.js
@@ -25,5 +25,5 @@ const myModel = Model('myModel', {
 
 const dataPoint = DataPoint.create()
 dataPoint.resolve(myModel, input).then(output => {
-  assert.equal(output, 30)
+  assert.strictEqual(output, 30)
 })

--- a/packages/data-point/examples/entity-model-before.js
+++ b/packages/data-point/examples/entity-model-before.js
@@ -13,5 +13,5 @@ dataPoint.addEntities({
 })
 
 dataPoint.resolve('model:foo', 100).then(output => {
-  assert.deepEqual(output, [100])
+  assert.deepStrictEqual(output, [100])
 })

--- a/packages/data-point/examples/entity-model-error-handled.js
+++ b/packages/data-point/examples/entity-model-error-handled.js
@@ -28,5 +28,5 @@ const input = {
 }
 
 dataPoint.resolve('model:getArray', input).then(output => {
-  assert.deepEqual(output, [])
+  assert.deepStrictEqual(output, [])
 })

--- a/packages/data-point/examples/entity-request-basic.js
+++ b/packages/data-point/examples/entity-request-basic.js
@@ -12,7 +12,7 @@ dataPoint.addEntities({
 mockRequest()
 
 dataPoint.resolve('request:getLuke', {}).then(output => {
-  assert.equal(output.name, 'Luke Skywalker')
-  assert.equal(output.height, '172')
+  assert.strictEqual(output.name, 'Luke Skywalker')
+  assert.strictEqual(output.height, '172')
   console.dir(output, { colors: true })
 })

--- a/packages/data-point/examples/entity-request-options-locals.js
+++ b/packages/data-point/examples/entity-request-options-locals.js
@@ -18,7 +18,7 @@ const options = {
 }
 
 dataPoint.resolve('request:getLuke', {}, options).then(output => {
-  assert.equal(output.name, 'Luke Skywalker')
-  assert.equal(output.height, '172')
+  assert.strictEqual(output.name, 'Luke Skywalker')
+  assert.strictEqual(output.height, '172')
   console.dir(output, { colors: true })
 })

--- a/packages/data-point/examples/entity-request-options.js
+++ b/packages/data-point/examples/entity-request-options.js
@@ -33,6 +33,6 @@ const input = {
 
 // the second parameter to transform is the input value
 dataPoint.resolve('request:searchPeople', input).then(output => {
-  assert.equal(output.results[0].name, 'R2-D2')
+  assert.strictEqual(output.results[0].name, 'R2-D2')
   console.dir(output, { colors: true })
 })

--- a/packages/data-point/examples/entity-request-string-template.js
+++ b/packages/data-point/examples/entity-request-string-template.js
@@ -16,7 +16,7 @@ const input = {
 }
 
 dataPoint.resolve('request:getLuke', input).then(output => {
-  assert.equal(output.name, 'Luke Skywalker')
-  assert.equal(output.height, '172')
+  assert.strictEqual(output.name, 'Luke Skywalker')
+  assert.strictEqual(output.height, '172')
   console.dir(output, { colors: true })
 })

--- a/packages/data-point/examples/extend-entity-keys.js
+++ b/packages/data-point/examples/extend-entity-keys.js
@@ -23,6 +23,6 @@ dataPoint.addEntities({
 })
 
 dataPoint.resolve('entry:Extended', '').then(output => {
-  assert.equal(output, 'before value after')
+  assert.strictEqual(output, 'before value after')
   console.log(output)
 })

--- a/packages/data-point/examples/model-type-check-custom.js
+++ b/packages/data-point/examples/model-type-check-custom.js
@@ -19,6 +19,6 @@ const input = {
 }
 
 dataPoint.resolve('model:string', input).then(output => {
-  assert.equal(output, 'DataPoint')
+  assert.strictEqual(output, 'DataPoint')
   console.log(output)
 })

--- a/packages/data-point/examples/model-type-check-helper.js
+++ b/packages/data-point/examples/model-type-check-helper.js
@@ -14,6 +14,6 @@ const input = {
 }
 
 dataPoint.resolve('model:string', input).then(output => {
-  assert.equal(output, 'DataPoint')
+  assert.strictEqual(output, 'DataPoint')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-array-closures.js
+++ b/packages/data-point/examples/reducer-array-closures.js
@@ -8,6 +8,6 @@ const addStr = word => input => {
 const reducers = [addStr(' World'), addStr('!!')]
 
 dataPoint.resolve(reducers, 'Hello').then(output => {
-  assert.equal(output, 'Hello World!!')
+  assert.strictEqual(output, 'Hello World!!')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-array-functions.js
+++ b/packages/data-point/examples/reducer-array-functions.js
@@ -8,6 +8,6 @@ const addStr = word => input => {
 const reducers = [addStr(' World'), addStr('!!')]
 
 dataPoint.resolve(reducers, 'Hello').then(output => {
-  assert.equal(output, 'Hello World!!')
+  assert.strictEqual(output, 'Hello World!!')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-array-mixed-2.js
+++ b/packages/data-point/examples/reducer-array-mixed-2.js
@@ -19,6 +19,6 @@ const getMax = () => input => {
 }
 
 dataPoint.resolve(['$a.b.c', getMax(), multiplyBy(10)], input).then(output => {
-  assert.equal(output, 30)
+  assert.strictEqual(output, 30)
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-array-mixed.js
+++ b/packages/data-point/examples/reducer-array-mixed.js
@@ -12,6 +12,6 @@ const toUpperCase = input => {
 }
 
 dataPoint.resolve(['$a.b', toUpperCase], input).then(output => {
-  assert.equal(output, 'HELLO WORLD')
+  assert.strictEqual(output, 'HELLO WORLD')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-conditional-operator.js
+++ b/packages/data-point/examples/reducer-conditional-operator.js
@@ -29,7 +29,7 @@ dataPoint.addEntities({
 mockRequests()
 
 dataPoint.resolve('reducer:getPerson[]', people).then(output => {
-  assert.deepEqual(output, [
+  assert.deepStrictEqual(output, [
     {
       name: 'Luke Skywalker',
       birthYear: '19BBY'

--- a/packages/data-point/examples/reducer-entity-instance.js
+++ b/packages/data-point/examples/reducer-entity-instance.js
@@ -18,7 +18,7 @@ const PersonModel = Model('PersonModel', {
 const dataPoint = DataPoint.create()
 
 dataPoint.resolve([PersonRequest, PersonModel], 1).then(output => {
-  assert.deepEqual(output, {
+  assert.deepStrictEqual(output, {
     name: 'Luke Skywalker',
     birthYear: '19BBY'
   })

--- a/packages/data-point/examples/reducer-function-closure.js
+++ b/packages/data-point/examples/reducer-function-closure.js
@@ -6,6 +6,6 @@ const addStr = value => input => {
 }
 
 dataPoint.resolve(addStr(' World!!'), 'Hello').then(output => {
-  assert.equal(output, 'Hello World!!')
+  assert.strictEqual(output, 'Hello World!!')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-function-promise.js
+++ b/packages/data-point/examples/reducer-function-promise.js
@@ -7,5 +7,5 @@ const reducer = input => {
 
 dataPoint.resolve(reducer, 'Hello').then(output => {
   console.log(output)
-  assert.equal(output, 'Hello World')
+  assert.strictEqual(output, 'Hello World')
 })

--- a/packages/data-point/examples/reducer-function-sync.js
+++ b/packages/data-point/examples/reducer-function-sync.js
@@ -7,5 +7,5 @@ const reducer = input => {
 
 dataPoint.resolve(reducer, 'Hello').then(output => {
   console.log(output)
-  assert.equal(output, 'Hello World')
+  assert.strictEqual(output, 'Hello World')
 })

--- a/packages/data-point/examples/reducer-function-with-callback.js
+++ b/packages/data-point/examples/reducer-function-with-callback.js
@@ -6,6 +6,6 @@ const reducer = (input, acc, next) => {
 }
 
 dataPoint.resolve(reducer, 'Hello').then(output => {
-  assert.equal(output, 'Hello World')
+  assert.strictEqual(output, 'Hello World')
   console.log(output)
 })

--- a/packages/data-point/examples/reducer-helper-assign.js
+++ b/packages/data-point/examples/reducer-helper-assign.js
@@ -18,7 +18,7 @@ const reducer = DataPoint.assign({
 })
 
 dataPoint.resolve(reducer, value).then(output => {
-  assert.deepEqual(output, {
+  assert.deepStrictEqual(output, {
     a: 1,
     b: {
       c: 2

--- a/packages/data-point/examples/reducer-helper-filter.js
+++ b/packages/data-point/examples/reducer-helper-filter.js
@@ -18,5 +18,5 @@ const value = [
 const reducer = DataPoint.filter(['$a', input => input > 1])
 
 dataPoint.resolve(reducer, value).then(output => {
-  assert.deepEqual(output, [{ a: 2 }])
+  assert.deepStrictEqual(output, [{ a: 2 }])
 })

--- a/packages/data-point/examples/reducer-helper-find.js
+++ b/packages/data-point/examples/reducer-helper-find.js
@@ -18,7 +18,7 @@ const value = [
 const reducer = DataPoint.find('$b')
 
 dataPoint.resolve(reducer, value).then(output => {
-  assert.deepEqual(output, {
+  assert.deepStrictEqual(output, {
     b: 2
   })
 })

--- a/packages/data-point/examples/reducer-helper-map.js
+++ b/packages/data-point/examples/reducer-helper-map.js
@@ -18,5 +18,5 @@ const value = [
 const reducer = DataPoint.map(['$a', input => input * 2])
 
 dataPoint.resolve(reducer, value).then(output => {
-  assert.deepEqual(output, [2, 4])
+  assert.deepStrictEqual(output, [2, 4])
 })

--- a/packages/data-point/examples/reducer-path.js
+++ b/packages/data-point/examples/reducer-path.js
@@ -25,11 +25,11 @@ const input = {
 }
 
 dataPoint.resolve('$a.b', input).then(output => {
-  assert.equal(output, 'Hello World')
+  assert.strictEqual(output, 'Hello World')
   console.log(output)
 })
 
 dataPoint.resolve('$d.e[]', input.c).then(output => {
-  assert.deepEqual(output, [1, 2, 3])
+  assert.deepStrictEqual(output, [1, 2, 3])
   console.log(output)
 })

--- a/packages/data-point/examples/registered-entities.js
+++ b/packages/data-point/examples/registered-entities.js
@@ -75,11 +75,11 @@ const input = {
 mocks()
 
 dataPoint.resolve('model:Planet', input).then(output => {
-  assert.equal(output.name, 'Tatooine')
-  assert.equal(output.population, '200000')
+  assert.strictEqual(output.name, 'Tatooine')
+  assert.strictEqual(output.population, '200000')
   assert.ok(output.residents.length > 0)
 
-  assert.deepEqual(output.residents[0], {
+  assert.deepStrictEqual(output.residents[0], {
     name: 'Luke Skywalker',
     gender: 'male',
     birthYear: '19BBY'


### PR DESCRIPTION
**What**: Replace the deprecated methods `assert.equal` / `assert.deepEqual` with `assert.strictEqual` / `assert.deepStrictEqual`

<!-- Why are these changes necessary? -->
**Why**: The linter began complaining about the deprecated methods, and that causes travis to fail.
