### PR TITLE
feat(data-point): Add more functionality to the inspect function for request entities

### DIFF
--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -2272,10 +2272,33 @@ dataPoint.addEntities({
 })
 ```
 
-If `params.inspect` is `true` it will output the entity's information to the console.
+**Boolean**
 
-If `params.inspect` is a `function`, you may execute custom debugging code to be executed before the actual request gets made. The function receives the current accumulator value as its only parameter.
+If `params.inspect` is `true`, it will output the entity's information to the console.
 
+**Function**
+
+If `params.inspect` is a function, it will be called twice: once before the request is made, and once when the request is resolved. It should have the signature ```(accumulator: Object, data: Object)```.
+
+The `inspect` function is first called just before initiating the request. The first argument is the `accumulator`, and the second is a `data` object with these properties:
+
+```js
+{
+  type: 'request',
+  method: String, // ex: 'GET'
+  uri: String, // fully-formed URI
+  [body]: String // the value of request.body (or undefined)
+}
+```
+
+It's then called when the request succeeds or fails. The `data` object will have a `type` property of either `'response'` or `'error'`:
+
+```js
+{
+  type: 'response|error',
+  statusCode: Number,
+}
+```
 
 ### Hash
 

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -2254,7 +2254,7 @@ Example at: [examples/entity-request-options.js](examples/entity-request-options
 
 For more examples of request entities, see the [Examples](examples), the [Integration Examples](test/definitions/integrations.js), and the unit tests: [Request Definitions](test/definitions/requests.js).
 
-#### Inspecting Request
+#### Inspecting Request Entities
 
 You may inspect a Request entity through the `params.inspect` property.
 
@@ -2285,17 +2285,25 @@ The `inspect` function is first called just before initiating the request. The f
 ```js
 {
   type: 'request',
-  method: String, // ex: 'GET'
-  uri: String, // fully-formed URI
-  [body]: String // the value of request.body (or undefined)
+  // unique ID that is shared with the 'response' object
+  debugId: Number,
+  // ex: 'GET'
+  method: String,
+  // fully-formed URI
+  uri: String,
+  // the value of request.body (or undefined)
+  [body]: String
 }
 ```
 
-It's then called when the request succeeds or fails. The `data` object will have a `type` property of either `'response'` or `'error'`:
+It's then called when the request succeeds or fails. The `data` object will have a `type` property of either `'response'` or `'error'`. The `debugId` can be used to match the response with the corresponding request.
 
 ```js
 {
   type: 'response|error',
+  // unique ID that is shared with the 'request' object
+  debugId: Number,
+  // http status code
   statusCode: Number,
 }
 ```

--- a/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
+++ b/packages/data-point/lib/entity-types/entity-request/__snapshots__/resolve.test.js.snap
@@ -18,10 +18,10 @@ Entity info:
   method: 'GET',
   json: true,
   url: 'http://remote.test/source1',
+  resolveWithFullResponse: true,
   callback: [Function: RP$callback],
   transform: undefined,
   simple: true,
-  resolveWithFullResponse: false,
   transform2xxOnly: false }
 "
 `;
@@ -42,10 +42,10 @@ Entity info:
   - statusCode: 404
   - options: { json: true,
   url: 'http://remote.test/source1',
+  resolveWithFullResponse: true,
   callback: [Function: RP$callback],
   transform: undefined,
   simple: true,
-  resolveWithFullResponse: false,
   transform2xxOnly: false,
   auth: '[omitted]' }
 "

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -120,14 +120,14 @@ function inspect (acc, request) {
     // the paramInspect callback
     request
       .then(res => {
-        paramInspect(acc, {
+        _.attempt(paramInspect, acc, {
           type: 'response',
           statusCode: res.statusCode,
           headers: res.headers
         })
       })
       .catch(error => {
-        paramInspect(acc, {
+        _.attempt(paramInspect, acc, {
           type: 'error',
           statusCode: error.statusCode,
           headers: error.headers

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -115,6 +115,9 @@ function inspect (acc, request) {
       data.body = request.body.toString('utf8')
     }
     paramInspect(acc, data)
+    // This promise chain should not be returned,
+    // because it is only being used to trigger
+    // the paramInspect callback
     request
       .then(res => {
         paramInspect(acc, {

--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -5,6 +5,8 @@ const rp = require('request-promise')
 
 const utils = require('../../utils')
 
+let debugIdCounter = 0
+
 /**
  * request's default options
  * @type {Object}
@@ -105,7 +107,9 @@ function inspect (acc, request) {
 
   if (typeof paramInspect === 'function') {
     // some of this logic borrows from https://github.com/request/request-debug
+    const debugId = ++debugIdCounter
     const data = {
+      debugId,
       type: 'request',
       uri: request.uri.href,
       method: request.method,
@@ -121,6 +125,7 @@ function inspect (acc, request) {
     request
       .then(res => {
         _.attempt(paramInspect, acc, {
+          debugId,
           type: 'response',
           statusCode: res.statusCode,
           headers: res.headers
@@ -128,6 +133,7 @@ function inspect (acc, request) {
       })
       .catch(error => {
         _.attempt(paramInspect, acc, {
+          debugId,
           type: 'error',
           statusCode: error.statusCode,
           headers: error.headers

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -338,10 +338,8 @@ describe('inspect', () => {
   }
   function createMockRequest (options) {
     let { statusCode, requestType, rpOptions } = options
-    requestType = requestType.toLowerCase()
-    nock('http://remote.test')
-      [requestType]('/')
-      .reply(statusCode, { statusCode })
+    const nockInstance = nock('http://remote.test')
+    nockInstance[requestType]('/').reply(statusCode, { statusCode })
     return rp[requestType]({
       uri: 'http://remote.test',
       resolveWithFullResponse: true,
@@ -352,7 +350,7 @@ describe('inspect', () => {
   test('It should not execute params.inspect or utils.inspect when inspect is undefined', async () => {
     const acc = createAcc()
     acc.params.inspect = undefined
-    const request = createMockRequest({ statusCode: 200, requestType: 'GET' })
+    const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
@@ -360,7 +358,7 @@ describe('inspect', () => {
   test('It should not execute params.inspect or utils.inspect when inspect is false', async () => {
     const acc = createAcc()
     acc.params.inspect = false
-    const request = createMockRequest({ statusCode: 200, requestType: 'GET' })
+    const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
@@ -368,7 +366,7 @@ describe('inspect', () => {
   test('It should execute utils.inspect when params.inspect === true', async () => {
     const acc = createAcc()
     acc.params.inspect = true
-    const request = createMockRequest({ statusCode: 200, requestType: 'GET' })
+    const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     Resolve.inspect(acc, request)
     await expect(request).resolves.toBeTruthy()
     expect(utilsInspectSpy).toBeCalledWith(
@@ -380,12 +378,13 @@ describe('inspect', () => {
     )
   })
   test('It should execute params.inspect when rp.then is called', async () => {
-    const statusCode = 200
-    const requestType = 'GET'
-    const rpOptions = {}
     const acc = createAcc()
     acc.params.inspect = jest.fn()
-    const request = createMockRequest({ statusCode, requestType, rpOptions })
+    const request = createMockRequest({
+      statusCode: 200,
+      requestType: 'get',
+      rpOptions: {}
+    })
     Resolve.inspect(acc, request)
     await expect(request).resolves.toBeTruthy()
     expect(utilsInspectSpy).not.toBeCalled()
@@ -394,26 +393,27 @@ describe('inspect', () => {
         acc,
         expect.objectContaining({
           type: 'request',
-          method: requestType.toUpperCase(),
+          method: 'GET',
           uri: expect.stringMatching('http://remote.test')
         })
       ],
       [
         acc,
         expect.objectContaining({
-          statusCode,
+          statusCode: 200,
           type: 'response'
         })
       ]
     ])
   })
   test('It should execute params.inspect when rp.catch is called', async () => {
-    const statusCode = 404
-    const requestType = 'GET'
-    const rpOptions = {}
     const acc = createAcc()
     acc.params.inspect = jest.fn()
-    const request = createMockRequest({ statusCode, requestType, rpOptions })
+    const request = createMockRequest({
+      statusCode: 404,
+      requestType: 'get',
+      rpOptions: {}
+    })
     Resolve.inspect(acc, request)
     await expect(request).rejects.toBeTruthy()
     expect(utilsInspectSpy).not.toBeCalled()
@@ -422,27 +422,30 @@ describe('inspect', () => {
         acc,
         expect.objectContaining({
           type: 'request',
-          method: requestType.toUpperCase(),
+          method: 'GET',
           uri: expect.stringMatching('http://remote.test')
         })
       ],
       [
         acc,
         expect.objectContaining({
-          statusCode,
+          statusCode: 404,
           type: 'error'
         })
       ]
     ])
   })
   test('It should include the body in the event', async () => {
-    const statusCode = 200
-    const requestType = 'POST'
-    const bodyData = JSON.stringify({ test: true })
-    const rpOptions = { body: bodyData }
     const acc = createAcc()
     acc.params.inspect = jest.fn()
-    const request = createMockRequest({ statusCode, requestType, rpOptions })
+    const bodyData = JSON.stringify({ test: true })
+    const request = createMockRequest({
+      statusCode: 200,
+      requestType: 'post',
+      rpOptions: {
+        body: bodyData
+      }
+    })
     Resolve.inspect(acc, request)
     await expect(request).resolves.toBeTruthy()
     const mockArguments = acc.params.inspect.mock.calls.slice(0, 2)
@@ -452,7 +455,7 @@ describe('inspect', () => {
         acc,
         expect.objectContaining({
           type: 'request',
-          method: requestType.toUpperCase(),
+          method: 'POST',
           uri: expect.stringMatching('http://remote.test'),
           body: expect.stringMatching(bodyData)
         })
@@ -460,7 +463,7 @@ describe('inspect', () => {
       [
         acc,
         expect.objectContaining({
-          statusCode,
+          statusCode: 200,
           type: 'response'
         })
       ]

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -327,14 +327,15 @@ describe('inspect', () => {
     utilsInspectSpy.mockRestore()
   })
 
-  function createAcc () {
-    const acc = {
+  function createAcc (inspectParam) {
+    return {
       value: 'boomerang',
-      params: {},
       options: {},
+      params: {
+        inspect: inspectParam
+      },
       reducer: _.set({}, 'spec.id', 'test:test')
     }
-    return acc
   }
   function createMockRequest (options) {
     let { statusCode, requestType, rpOptions } = options
@@ -347,25 +348,22 @@ describe('inspect', () => {
     })
   }
 
-  test('It should not execute params.inspect or utils.inspect when inspect is undefined', async () => {
-    const acc = createAcc()
-    acc.params.inspect = undefined
+  test('It should ignore params.inspect and utils.inspect when params.inspect is undefined', async () => {
+    const acc = createAcc(undefined)
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
   })
-  test('It should not execute params.inspect or utils.inspect when inspect is false', async () => {
-    const acc = createAcc()
-    acc.params.inspect = false
+  test('It should ignore params.inspect and utils.inspect when params.inspect is false', async () => {
+    const acc = createAcc(false)
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
   })
   test('It should execute utils.inspect when params.inspect === true', async () => {
-    const acc = createAcc()
-    acc.params.inspect = true
+    const acc = createAcc(true)
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     Resolve.inspect(acc, request)
     await expect(request).resolves.toBeTruthy()
@@ -378,8 +376,7 @@ describe('inspect', () => {
     )
   })
   test('It should execute params.inspect when rp.then is called', async () => {
-    const acc = createAcc()
-    acc.params.inspect = jest.fn()
+    const acc = createAcc(jest.fn())
     const request = createMockRequest({
       statusCode: 200,
       requestType: 'get',
@@ -407,8 +404,7 @@ describe('inspect', () => {
     ])
   })
   test('It should execute params.inspect when rp.catch is called', async () => {
-    const acc = createAcc()
-    acc.params.inspect = jest.fn()
+    const acc = createAcc(jest.fn())
     const request = createMockRequest({
       statusCode: 404,
       requestType: 'get',
@@ -436,8 +432,7 @@ describe('inspect', () => {
     ])
   })
   test('It should include the body in the event', async () => {
-    const acc = createAcc()
-    acc.params.inspect = jest.fn()
+    const acc = createAcc(jest.fn())
     const bodyData = JSON.stringify({ test: true })
     const request = createMockRequest({
       statusCode: 200,

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -348,14 +348,14 @@ describe('inspect', () => {
     })
   }
 
-  test('It should ignore params.inspect and utils.inspect when params.inspect is undefined', async () => {
+  test('It should ignore params.inspect and utils.inspect when params.inspect === undefined', async () => {
     const acc = createAcc({ inspect: undefined })
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
   })
-  test('It should ignore params.inspect and utils.inspect when params.inspect is false', async () => {
+  test('It should ignore params.inspect and utils.inspect when params.inspect === false', async () => {
     const acc = createAcc({ inspect: false })
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
@@ -431,7 +431,7 @@ describe('inspect', () => {
       ]
     ])
   })
-  test('It should include the body in the event', async () => {
+  test('It should pass the body option to params.inspect', async () => {
     const acc = createAcc({ inspect: jest.fn() })
     const bodyData = JSON.stringify({ test: true })
     const request = createMockRequest({

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -327,12 +327,12 @@ describe('inspect', () => {
     utilsInspectSpy.mockRestore()
   })
 
-  function createAcc (inspectParam) {
+  function createAcc ({ inspect }) {
     return {
       value: 'boomerang',
       options: {},
       params: {
-        inspect: inspectParam
+        inspect
       },
       reducer: _.set({}, 'spec.id', 'test:test')
     }
@@ -349,21 +349,21 @@ describe('inspect', () => {
   }
 
   test('It should ignore params.inspect and utils.inspect when params.inspect is undefined', async () => {
-    const acc = createAcc(undefined)
+    const acc = createAcc({ inspect: undefined })
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
   })
   test('It should ignore params.inspect and utils.inspect when params.inspect is false', async () => {
-    const acc = createAcc(false)
+    const acc = createAcc({ inspect: false })
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     await expect(request).resolves.toBeTruthy()
     Resolve.inspect(acc, request)
     expect(utilsInspectSpy).not.toBeCalled()
   })
   test('It should execute utils.inspect when params.inspect === true', async () => {
-    const acc = createAcc(true)
+    const acc = createAcc({ inspect: true })
     const request = createMockRequest({ statusCode: 200, requestType: 'get' })
     Resolve.inspect(acc, request)
     await expect(request).resolves.toBeTruthy()
@@ -376,7 +376,7 @@ describe('inspect', () => {
     )
   })
   test('It should execute params.inspect when rp.then is called', async () => {
-    const acc = createAcc(jest.fn())
+    const acc = createAcc({ inspect: jest.fn() })
     const request = createMockRequest({
       statusCode: 200,
       requestType: 'get',
@@ -404,7 +404,7 @@ describe('inspect', () => {
     ])
   })
   test('It should execute params.inspect when rp.catch is called', async () => {
-    const acc = createAcc(jest.fn())
+    const acc = createAcc({ inspect: jest.fn() })
     const request = createMockRequest({
       statusCode: 404,
       requestType: 'get',
@@ -432,7 +432,7 @@ describe('inspect', () => {
     ])
   })
   test('It should include the body in the event', async () => {
-    const acc = createAcc(jest.fn())
+    const acc = createAcc({ inspect: jest.fn() })
     const bodyData = JSON.stringify({ test: true })
     const request = createMockRequest({
       statusCode: 200,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: fix #324

<!-- Why are these changes necessary? -->
**Why**: This adds more functionality to the `inspect` function for request entities. The function now has two parameters: `accumulator` and `data`, where the data object contains information like the fully-formed URI and the response status code. This replaces #328, which introduced the `request-debug` library as a dependency.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added username to **all-contributors** list

