### PR TITLE
feat(data-point): Use _.attempt when calling user defined inspect functions

### DIFF
--- a/packages/data-point/lib/entity-types/entity-request/resolve.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.js
@@ -118,7 +118,7 @@ function inspect (acc, request) {
     if (request.body) {
       data.body = request.body.toString('utf8')
     }
-    paramInspect(acc, data)
+    _.attempt(paramInspect, acc, data)
     // This promise chain should not be returned,
     // because it is only being used to trigger
     // the paramInspect callback

--- a/packages/data-point/lib/entity-types/entity-request/resolve.test.js
+++ b/packages/data-point/lib/entity-types/entity-request/resolve.test.js
@@ -381,7 +381,12 @@ describe('inspect', () => {
     )
   })
   test('It should execute params.inspect when rp.then is called', async () => {
-    const acc = createAcc({ inspect: jest.fn() })
+    const acc = createAcc({
+      inspect: jest.fn(() => {
+        // This helps verify that _.attempt is used when calling inspect
+        throw new Error()
+      })
+    })
     const request = createMockRequest({
       statusCode: 200,
       requestType: 'get'
@@ -410,7 +415,12 @@ describe('inspect', () => {
     ])
   })
   test('It should execute params.inspect when rp.catch is called', async () => {
-    const acc = createAcc({ inspect: jest.fn() })
+    const acc = createAcc({
+      inspect: jest.fn(() => {
+        // This helps verify that _.attempt is used when calling inspect
+        throw new Error()
+      })
+    })
     const request = createMockRequest({
       statusCode: 404,
       requestType: 'get'


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Use `lodash.attempt` when calling `inspect` functions

<!-- Why are these changes necessary? -->
**Why**: Helps prevent user errors from crashing data-point

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
