### PR TITLE
fix(data-point-service): fixes revalidation logic

### DIFF
--- a/packages/data-point-service/examples/express-cache-stale-while-revalidate-instance-entity.js
+++ b/packages/data-point-service/examples/express-cache-stale-while-revalidate-instance-entity.js
@@ -1,0 +1,59 @@
+const express = require('express')
+const DataPoint = require('data-point')
+const DataPointService = require('../lib')
+
+function server (dataPoint) {
+  const app = express()
+
+  app.get('/api/hello-world', (req, res) => {
+    const options = {
+      // exposing query to locals will make this object available to all
+      // reducers
+      locals: {
+        query: req.query
+      }
+    }
+    dataPoint
+      .resolve(`model:HelloWorld`, {}, options)
+      .then(value => {
+        const responseText = `${value} (person = "${req.query.person}")`
+        res.send(responseText)
+      })
+      .catch(error => {
+        res.status(500).send(error.toString())
+      })
+  })
+
+  app.listen(3000, function () {
+    console.log('listening on port 3000!')
+  })
+}
+
+function createService () {
+  return DataPointService.create({
+    DataPoint,
+    entities: {
+      'model:HelloWorld': {
+        value: (input, acc) => {
+          const person = acc.locals.query.person
+          if (!person) {
+            throw new Error(
+              'Url query parameter "person" is missing. Try appending ?person=Darek at the end of the URL'
+            )
+          }
+          return `Hello ${person}!!`
+        },
+        params: {
+          cache: {
+            ttl: '30s',
+            staleWhileRevalidate: '3m'
+          }
+        }
+      }
+    }
+  }).then(service => {
+    return service.dataPoint
+  })
+}
+
+createService().then(server)

--- a/packages/data-point-service/examples/express-cache-stale-while-revalidate-registered-entity.js
+++ b/packages/data-point-service/examples/express-cache-stale-while-revalidate-registered-entity.js
@@ -2,6 +2,24 @@ const express = require('express')
 const DataPoint = require('data-point')
 const DataPointService = require('../lib')
 
+const Model = DataPoint.Model('HelloWorld', {
+  value: (input, acc) => {
+    const person = acc.locals.query.person
+    if (!person) {
+      throw new Error(
+        'Url query parameter "person" is missing. Try appending ?person=Darek at the end of the URL'
+      )
+    }
+    return `Hello ${person}!!`
+  },
+  params: {
+    cache: {
+      ttl: '30s',
+      staleWhileRevalidate: '3m'
+    }
+  }
+})
+
 function server (dataPoint) {
   const app = express()
 
@@ -14,7 +32,7 @@ function server (dataPoint) {
       }
     }
     dataPoint
-      .resolve(`model:HelloWorld`, {}, options)
+      .resolve(Model, {}, options)
       .then(value => {
         const responseText = `${value} (person = "${req.query.person}")`
         res.send(responseText)
@@ -31,26 +49,7 @@ function server (dataPoint) {
 
 function createService () {
   return DataPointService.create({
-    DataPoint,
-    entities: {
-      'model:HelloWorld': {
-        value: (input, acc) => {
-          const person = acc.locals.query.person
-          if (!person) {
-            throw new Error(
-              'Url query parameter "person" is missing. Try appending ?person=Darek at the end of the URL'
-            )
-          }
-          return `Hello ${person}!!`
-        },
-        params: {
-          cache: {
-            ttl: '1m',
-            staleWhileRevalidate: '3m'
-          }
-        }
-      }
-    }
+    DataPoint
   }).then(service => {
     return service.dataPoint
   })

--- a/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/cache-middleware.test.js.snap
@@ -36,6 +36,11 @@ Array [
     "model:Foo",
     "entryKey",
   ],
+  Array [
+    "Resolve entryKey: %s with entityId: %s",
+    "entryKey",
+    "model:Foo",
+  ],
 ]
 `;
 

--- a/packages/data-point-service/lib/__snapshots__/data-point-factory.test.js.snap
+++ b/packages/data-point-service/lib/__snapshots__/data-point-factory.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`verify It should throw error if entities not provided 1`] = `"DataPoint options.entities should not be Empty"`;

--- a/packages/data-point-service/lib/cache-middleware.test.js
+++ b/packages/data-point-service/lib/cache-middleware.test.js
@@ -196,7 +196,7 @@ describe('revalidateEntry', () => {
       .spyOn(CacheMiddleware, 'catchRevalidateError')
       .mockImplementation(() => () => Promise.resolve('catchRevalidateError'))
 
-    mocks.addRevalidationFlags = jest.fn(() => () => Promise.resolve('flags'))
+    mocks.addRevalidationFlags = jest.fn(() => Promise.resolve('flags'))
     mocks.service = {}
     _.set(
       mocks.service,
@@ -268,7 +268,7 @@ describe('revalidateEntry', () => {
       const resolveFromAccumulatorArgs =
         mocks.resolveFromAccumulator.mock.calls[0]
 
-      expect(resolveFromAccumulatorArgs[0]).toEqual('model:Foo')
+      expect(resolveFromAccumulatorArgs[0]).toEqual(ctx.context)
       expect(resolveFromAccumulatorArgs[1]).toHaveProperty(
         'locals.revalidatingCache',
         {

--- a/packages/data-point-service/lib/data-point-factory.js
+++ b/packages/data-point-service/lib/data-point-factory.js
@@ -1,12 +1,6 @@
-const _ = require('lodash')
-
 function verify (options) {
   if (!options.DataPoint) {
     throw new Error('DataPoint module must be provided')
-  }
-
-  if (_.isEmpty(options.entities)) {
-    throw new Error('DataPoint options.entities should not be Empty')
   }
 
   return options

--- a/packages/data-point-service/lib/data-point-factory.test.js
+++ b/packages/data-point-service/lib/data-point-factory.test.js
@@ -23,14 +23,6 @@ describe('verify', () => {
       })
     }).toThrowError(/provided/)
   })
-
-  test('It should throw error if entities not provided', () => {
-    expect(() => {
-      DataPointFactory.verify({
-        DataPoint
-      })
-    }).toThrowErrorMatchingSnapshot()
-  })
 })
 
 describe('createDataPoint', () => {

--- a/packages/data-point-service/lib/stale-while-revalidate.test.js
+++ b/packages/data-point-service/lib/stale-while-revalidate.test.js
@@ -187,14 +187,29 @@ describe('getRevalidationState', () => {
     _.set(
       revalidation,
       'external.exists',
-      jest.fn(() => Promise.resolve('externalState'))
+      jest.fn(() => Promise.resolve(false))
     )
 
     return StaleWhileRevalidate.getRevalidationState(
       revalidation,
       'entryKey'
     ).then(result => {
-      expect(result.hasExternalEntryExpired).toEqual('externalState')
+      expect(result.hasExternalEntryExpired).toEqual(true)
+      expect(result.isRevalidatingLocally).toBeInstanceOf(Function)
+      expect(result.isRevalidatingLocally()).toEqual('localState')
+    })
+  })
+
+  it('should return hasExternalEntryExpired === true if exists == false', () => {
+    const revalidation = {}
+    _.set(revalidation, 'local.exists', jest.fn(() => 'localState'))
+    _.set(revalidation, 'external.exists', jest.fn(() => Promise.resolve(true)))
+
+    return StaleWhileRevalidate.getRevalidationState(
+      revalidation,
+      'entryKey'
+    ).then(result => {
+      expect(result.hasExternalEntryExpired).toEqual(false)
       expect(result.isRevalidatingLocally).toBeInstanceOf(Function)
       expect(result.isRevalidatingLocally()).toEqual('localState')
     })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

- fix bug where revalidation was not being triggered
- provides support registered and instance entities

<!-- Why are these changes necessary? -->
**Why**:

closes #340

<!-- How were these changes implemented? -->
**How**:

passing the entity reducer (accumulator.context) to resolveFromAccumulator, and fixed logic to detect when a remote (redis) entry should revalidate.

I also added more debugging logs since it was getting harder to track the steps, this should help in the future, below is an example of the output of running one of the examples: 

```bash
  data-point:entity:model model:HelloWorld:1 - resolve:start +0ms
  data-point-service:cache:stale-while-revalidate External control exists: false - entity:model:HelloWorld +0ms
  data-point:entity:model model:HelloWorld:1 - resolve +30ms
  data-point-service:cache:stale-while-revalidate Adding entry - entity:model:HelloWorld +4ms
  data-point-service:cache:stale-while-revalidate Setting control to status: SWR-CONTROL-STALE - entity:model:HelloWorld +6ms
  data-point:entity:model model:HelloWorld:1 - resolve:end +9ms
-------------manually expiring control key--------------  data-point:entity:model model:HelloWorld:2 - resolve:start +52s
  data-point-service:cache:stale-while-revalidate External control exists: false - entity:model:HelloWorld +52s
  data-point-service:cache Revalidating entityId: model:HelloWorld with cache key: entity:model:HelloWorld +0ms
  data-point-service:cache:stale-while-revalidate Add revalidation control flags - timeout: 5000ms - entity:model:HelloWorld +8ms
  data-point-service:cache:stale-while-revalidate Setting control to status: SWR-CONTROL-REVALIDATING (5000ms ttl) - entity:model:HelloWorld +0ms
  data-point:entity:model model:HelloWorld:2 - will bypass +14ms
  data-point:entity:model model:HelloWorld:2 - resolve:end +4ms
  data-point-service:cache Resolve entryKey: entity:model:HelloWorld with entityId: model:HelloWorld +11ms
  data-point:entity:model model:HelloWorld:3 - resolve:start +5ms
  data-point:entity:model model:HelloWorld:3 - resolve +2ms
  data-point:entity:model model:HelloWorld:3 - resolve:end +1ms
  data-point-service:cache Updating cache key: entity:model:HelloWorld with new stale value +5ms
  data-point-service:cache:stale-while-revalidate Adding entry - entity:model:HelloWorld +15ms
  data-point-service:cache:stale-while-revalidate Setting control to status: SWR-CONTROL-STALE - entity:model:HelloWorld +4ms
  data-point-service:cache Succesful revalidation entityId: model:HelloWorld with cache key: entity:model:HelloWorld +10ms
```

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
