### PR TITLE
fix: Fix bug when the input to a reducer list is undefined

### DIFF
--- a/packages/data-point/lib/reducer-types/reducer-list/resolve.js
+++ b/packages/data-point/lib/reducer-types/reducer-list/resolve.js
@@ -15,13 +15,15 @@ function resolve (manager, resolveReducer, accumulator, reducerList) {
     return Promise.resolve(undefined)
   }
 
+  const initialValue =
+    accumulator.value === undefined ? null : accumulator.value
   const result = Promise.reduce(
     reducers,
     (value, reducer) => {
       const itemContext = utils.set(accumulator, 'value', value)
       return resolveReducer(manager, itemContext, reducer)
     },
-    accumulator.value
+    initialValue
   )
 
   return result

--- a/packages/data-point/lib/reducer-types/reducer-list/resolve.test.js
+++ b/packages/data-point/lib/reducer-types/reducer-list/resolve.test.js
@@ -153,3 +153,42 @@ describe('resolve#reducer.resolve - reducer request', () => {
     })
   })
 })
+
+describe('resolve#reducer.resolve - with falsy input', () => {
+  const testFalsyInput = async (inputValue, expectedValue) => {
+    const accumulator = AccumulatorFactory.create({
+      value: inputValue
+    })
+
+    const functionA = jest.fn(input => `${input}1`)
+    const functionB = jest.fn(input => `${input}2`)
+
+    const reducerList = createReducerList(createReducer, [functionA, functionB])
+
+    const result = await resolveReducerList(
+      manager,
+      resolveReducer,
+      accumulator,
+      reducerList
+    )
+    expect(result).toBe(expectedValue)
+    expect(functionA).toHaveBeenCalledTimes(1)
+    expect(functionB).toHaveBeenCalledTimes(1)
+  }
+
+  test('with undefined as input', () => {
+    return testFalsyInput(undefined, 'null12')
+  })
+
+  test('with null as input', () => {
+    return testFalsyInput(null, 'null12')
+  })
+
+  test('with zero as input', () => {
+    return testFalsyInput(0, '012')
+  })
+
+  test('with an empty string as input', () => {
+    return testFalsyInput('', '12')
+  })
+})


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What (Bugfix)**: Reducer lists currently skip the first reducer when the initial value is undefined

<!-- Why are these changes necessary? -->
**Why**: #353

<!-- How were these changes implemented? -->
**How**: Use null as a fallback when the initial value for Promise.map is undefined

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added username to **all-contributors** list

<!-- feel free to add additional comments -->
