### PR TITLE
fix(data-point): ReducerEntity is now rethrowing error when not handled

### DIFF
--- a/packages/data-point/src/ReducerEntity.js
+++ b/packages/data-point/src/ReducerEntity.js
@@ -85,11 +85,13 @@ class ReducerEntity extends Reducer {
 
       if (this.catch) {
         acc = acc.set("value", await resolveReducer(acc, this.catch));
+        if (this.outputType) {
+          await resolveReducer(acc, this.outputType);
+        }
+        return acc.value;
       }
 
-      if (this.outputType) {
-        await resolveReducer(acc, this.outputType);
-      }
+      throw error;
     }
 
     return acc.value;

--- a/packages/data-point/src/ReducerEntity.test.js
+++ b/packages/data-point/src/ReducerEntity.test.js
@@ -138,7 +138,7 @@ describe("ReducerEntity", () => {
         expect(error.reducer).toEqual(entity);
       });
 
-      it.only("should resolve this.catch", async () => {
+      it("should resolve this.catch", async () => {
         const entity = new ReducerEntity("type", {
           name: "customEntity",
           value: () => "value",

--- a/packages/data-point/src/ReducerEntity.test.js
+++ b/packages/data-point/src/ReducerEntity.test.js
@@ -130,9 +130,13 @@ describe("ReducerEntity", () => {
 
         const acc = new Accumulator();
 
-        const error = await entity
-          .resolveReducer(acc, mockResolveReducer)
-          .catch(err => err);
+        let error;
+
+        try {
+          await entity.resolveReducer(acc, mockResolveReducer);
+        } catch (err) {
+          error = err;
+        }
 
         expect(error).toMatchInlineSnapshot(`[Error: entityError]`);
         expect(error.reducer).toEqual(entity);

--- a/packages/data-point/src/ReducerEntity.test.js
+++ b/packages/data-point/src/ReducerEntity.test.js
@@ -138,7 +138,7 @@ describe("ReducerEntity", () => {
         expect(error.reducer).toEqual(entity);
       });
 
-      it("should resolve this.catch", async () => {
+      it.only("should resolve this.catch", async () => {
         const entity = new ReducerEntity("type", {
           name: "customEntity",
           value: () => "value",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

BREAKING CHANGES:

If your PR includes a breaking change, please submit it with a codemod under
data-point-codemods that will help users upgrade their codebase.

Breaking changes without a codemod will not be accepted unless a codemod is not
viable or does not apply to the specific situation.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Makes sure any error is re-thrown if not handled by the catch reducer

<!-- Why are these changes necessary? -->
**Why**:

ReducerEntity was not throwing error

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added username to **all-contributors** list

<!-- feel free to add additional comments -->