### PR TITLE
feat(redis-client): moved error logging to upper scope

### DIFF
--- a/packages/data-point-cache/lib/redis-client.js
+++ b/packages/data-point-cache/lib/redis-client.js
@@ -10,12 +10,11 @@ function reconnectOnError(err) {
 function redisDecorator(redis, resolve, reject) {
   let wasConnected = false;
   redis.on("error", error => {
+    console.error("ioredis - error", error.toString());
     if (!wasConnected) {
       redis.disconnect();
       reject(error);
-      return;
     }
-    console.error("ioredis - error", error.toString());
   });
 
   redis.on("ready", () => {


### PR DESCRIPTION
**What**: Moved error logging to upper scope
**Why**: If Redis wasn't already connected, we wouldn't have logged any error spawned by the client
**How**: Moved the error logging to the parent branch scope
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Has Breaking changes
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
- [ ] Added username to **all-contributors** list