### PR TITLE
ci(codecov): temporary disabled codecov from CI process

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -15,6 +15,6 @@ jobs:
       - run: yarn prettier --check "**/*.js"
       - run: yarn run lint
       - run: yarn test -- --maxWorkers=4
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # - uses: codecov/codecov-action@v1
+      #  with:
+      #    token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**What**: Temporarily disabled codecov
**Why**: It is blocking the main pipeline
**How**: Just commented the gh ci workflow
**Checklist**:
- [ ] Has Breaking changes
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
- [ ] Added username to **all-contributors** list
