### PR TITLE
Feat/remove support node 8

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -15,6 +15,6 @@ jobs:
       - run: yarn prettier --check "**/*.js"
       - run: yarn run lint
       - run: yarn test -- --maxWorkers=4
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # - uses: codecov/codecov-action@v1
+      #  with:
+      #    token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/packages/data-point-cache/README.md
+++ b/packages/data-point-cache/README.md
@@ -8,7 +8,7 @@ Factory method to create a simple cache API that you can use for data persistenc
 
 ## Requirements
 
-- Node 8 LTS (or higher)
+- Node 10 LTS (or higher)
 - [Redis](https://redis.io/) (Optional for development)
 
 ## Install

--- a/packages/data-point-express/README.md
+++ b/packages/data-point-express/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-- Node 8 LTS (or higher)
+- Node 10 LTS (or higher)
 - [Redis](https://redis.io/) (Optional for development)
 - Peer dependencies: [data-point](https://www.npmjs.com/package/data-point), [Express](https://www.npmjs.com/package/express)
 

--- a/packages/data-point-service/README.md
+++ b/packages/data-point-service/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-- Node 8 LTS (or higher)
+- Node 10 LTS (or higher)
 - [Redis](https://redis.io/) (Optional for development)
 
 ## Install

--- a/packages/data-point/README.md
+++ b/packages/data-point/README.md
@@ -8,7 +8,7 @@ DataPoint helps you reason with and streamline your data processing layer. With 
 
 **Prerequisites**
 
-Node v8 LTS or higher
+Node v10 LTS or higher
 
 **Installing**
 


### PR DESCRIPTION
BREAKING CHANGE: Node.js 8.0 is not supported anymore

**What**: Dropped support for Node.js 8.
**Why**: Node.js 8 reached the end of life on 31 December 2019
**How**: Removed tests for Node.js 8 and changed docs
**Checklist**:
- [x] Has Breaking changes
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [ ] Added username to **all-contributors** list